### PR TITLE
Add setting to toggle compiling of all files on watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [4.1.0] -
+## [4.1.0] - 2020-21-20
 
 ### Added
 - New setting `liveSassCompile.settings.compileOnWatch`
@@ -89,5 +89,6 @@ All notable changes to this project will be documented in this file.
 
 
 [Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.0.0...HEAD
+[4.1.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v3.0.0...v4.0.0
 [3.0.0]: https://github.com/ritwickdey/vscode-live-sass-compiler/compare/v2.2.1...v3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.1.0] -
+
+### Added
+- New setting `liveSassCompile.settings.compileOnWatch`
+    * When `true` it will automatically compile all Sass files when watching is started. *Default value is `true`*
+
 ## [4.0.0] - 2020-12-20
 ### Breaking changes
 - Output options are now only `expanded` and `compressed`

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -204,4 +204,17 @@ Set this to `true` to watch files on launch.
 
 </details>
 
+---
+
+<details>
+<summary>
+    liveSassCompile.settings.compileOnWatch<br />
+    Defines whether Live Sass should compile all files when it starts watching
+</summary>
+
+Set this to `false` if you don't want all Sass files to be compiled when Live Sass Compiler starts watching. 
+* _**Default:** `true`._
+
+</details>
+
 [glob pattern]: https://github.com/isaacs/node-glob/blob/master/README.md#glob-primer

--- a/package.json
+++ b/package.json
@@ -178,6 +178,11 @@
                     "default": false,
                     "description": "Set this to `true` if you want Live Sass Compiler to automatically start watching your .sass or .scss file when you open an applicable workspace\nDefault is `false`"
                 },
+                "liveSassCompile.settings.compileOnWatch": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set this to `false` if you don't want all Sass files to be compiled when Live Sass Compiler starts watching."
+                },
                 "liveSassCompile.settings.showOutputWindow": {
                     "type": "boolean",
                     "default": true,

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -26,12 +26,20 @@ export class AppModel {
     }
 
     StartWatching() {
+        const compileOnWatch = Helper.getConfigSettings<boolean>('compileOnWatch');
+
         if (this.isWatching) {
             WindowPopout.Inform('Already watching...');
         }
         else {
             this.isWatching = !this.isWatching;
-            this.compileAllFiles();
+            StatusBarUi.working();
+
+            if (compileOnWatch) {
+                this.compileAllFiles();
+            }
+
+            this.revertUIToWatchingStatusNow()
         }
     }
 
@@ -70,8 +78,6 @@ export class AppModel {
      */
     async compileAllFiles() {
         try {
-            StatusBarUi.working();
-
             const showOutputWindow = Helper.getConfigSettings<boolean>('showOutputWindow');
 
             await this.GenerateAllCssAndMap(showOutputWindow);
@@ -85,8 +91,6 @@ export class AppModel {
                 }
             );
         }
-
-        this.revertUIToWatchingStatusNow()
     }
 
     /**

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -33,13 +33,13 @@ export class AppModel {
         }
         else {
             this.isWatching = !this.isWatching;
-            StatusBarUi.working();
 
             if (compileOnWatch) {
                 this.compileAllFiles();
             }
-
-            this.revertUIToWatchingStatusNow()
+            else {
+                this.revertUIToWatchingStatusNow();
+            }
         }
     }
 
@@ -78,6 +78,8 @@ export class AppModel {
      */
     async compileAllFiles() {
         try {
+            StatusBarUi.working();
+            
             const showOutputWindow = Helper.getConfigSettings<boolean>('showOutputWindow');
 
             await this.GenerateAllCssAndMap(showOutputWindow);
@@ -91,6 +93,8 @@ export class AppModel {
                 }
             );
         }
+
+        this.revertUIToWatchingStatusNow();
     }
 
     /**

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -79,7 +79,7 @@ export class AppModel {
     async compileAllFiles() {
         try {
             StatusBarUi.working();
-            
+
             const showOutputWindow = Helper.getConfigSettings<boolean>('showOutputWindow');
 
             await this.GenerateAllCssAndMap(showOutputWindow);


### PR DESCRIPTION
Added a setting to allow the user to choose _not_ to have all files compiled when the extension begins watching.

Feature Request: https://github.com/ritwickdey/vscode-live-sass-compiler/issues/241

```
"liveSassCompile.settings.compileOnWatch": {
    "type": "boolean",
    "default": true,
    "description": "Set this to `false` if you don't want all Sass files to be compiled when Live Sass Compiler starts watching."
},
```

I also work on a project that has hundreds of styling files and I would only make changes when Live SASS was watching, so for many people it's an unnecessary performance hit. It should be noted I have the default set to `true`, so unless the user sets this setting to `false`, it will continue to compile on watch as it did before.

Added an entry to the `CHANGELOG.md`. Tried to run the extension testing script, but it didn't seem to do anything, not sure if that is a WIP.