### PR TITLE
v4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.3.1] - 2021-01-09
+
+### Fixed
+- Fixed [#10](https://github.com/glenn2223/vscode-live-sass-compiler/issues/10): Partial SASS files not triggering compilation of all files
+- Correction of output when running `liveSass.command.debugInclusion` and the file is excluded
+
 ## [4.3.0] - 2021-01-06
 
 ### Added
@@ -125,7 +131,8 @@ All notable changes to this project will be documented in this file.
 
 
 
-[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.0...HEAD
+[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.1...HEAD
+[4.3.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.0...v4.3.1
 [4.3.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.0.0...v4.1.0

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ A VSCode Extension that help you to compile/transpile your SASS/SCSS files to CS
 3. Press `F1` or `ctrl+shift+P` and type `Live Sass: Compile Sass - Without Watch Mode ` to compile SASS or SCSS for one time.
 
 ## Features
-* Live SASS & SCSS Compile.
+* Live SASS & SCSS compile.
 * Customizable file location of exported CSS.
-* Customizable exported CSS Style (`expanded`, `compressed`).
+* Customizable exported CSS style (`expanded`, `compressed`).
 * Customizable extension name (`.css` or `.min.css`).
-* Quick Status bar control.
-* Exclude Specific Folders by settings. 
-* Live Reload to browser (Dependency on `Live Server` extension).
-* Autoprefix Supported (See settings section)
+* Quick status bar control.
+* Exclude specific folders by settings. 
+* Live reload to browser (Dependency on `Live Server` extension).
+* Autoprefix support (See settings section)
 
 ## Installation
 Open VSCode Editor and Press `ctrl+P`, type `ext install glenn2223.live-sass`.
@@ -42,20 +42,13 @@ This extension has dependency on _[Live Server](https://marketplace.visualstudio
 - Output options are now only `expanded` and `compressed`
 - Only works on VS Code v1.50 and newer
 
-### 4.3.0 - 2021-01-06
+### 4.3.1 - 2021-01-09
 
-### Added
-- Support for workspaces with multiple folders
+### Fixed
+- Fixed [#10](https://github.com/glenn2223/vscode-live-sass-compiler/issues/10): Partial SASS files not triggering compilation of all files
+- Correction of output when running `liveSass.command.debugInclusion` and the file is excluded
 
-### Changed
-- **Out of preview!**
-- Small optimisation to some underlying async operations
-
-### Other
-- Small bit of general tidying, adjustment to README, new dev dependancy for @.types/glob
-
-## Changelog
-See the full changelog [here](CHANGELOG.md).
+*See the full changelog [here](CHANGELOG.md).*
 
 ## LICENSE
 This extension is licensed under the [MIT License](LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime with live browser reload.",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -244,7 +244,7 @@
         "webpack-cli": "^4.2.0"
     },
     "announcement": {
-        "onVersion": "4.1.0",
-        "message": "SassCompiler@4.1.0: Now running Sass (v6.14.8), configurable \"Watch On Launch\" and \"Compile On Launch\", fixes and more! Beware: breaking changes from v4.0.0"
+        "onVersion": "4.3.1",
+        "message": "SassCompiler v4.3.1: Bug fix for partial files not processing all files"
     }
 }

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -519,7 +519,7 @@ export class AppModel {
                                     return;
                                 }
                                 const filePaths = files
-                                    .filter((file) => this.isSassFile(file, isDebugging))
+                                    .filter((file) => this.isSassFile(file, isDebugging || isQueryPatternFixed))
                                     .map((file) => path.join(folder.uri.fsPath, file));
                                 return resolve(filePaths || []);
                             }
@@ -565,8 +565,8 @@ export class AppModel {
                 );
             } else if (await this.isSassFileExcluded(sassPath)) {
                 OutputWindow.Show(
-                    "Excluded based on your settings, please check your settings",
-                    ["The file currently open in the editor window isn't a sass file"],
+                    "File excluded",
+                    ["The file is excluded based on your settings, please check your configuration"],
                     true
                 );
             } else {


### PR DESCRIPTION
## 4.3.1 - 2021-01-09

### Fixed
- Fixed [#10](https://github.com/glenn2223/vscode-live-sass-compiler/issues/10): Partial SASS files not triggering compilation of all files
- Correction of output when running `liveSass.command.debugInclusion` and the file is excluded