### PR TITLE
v4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.3.2] - 2021-01-15
+
+### Fixed
+- Now handle errors caused by incorrect autoprfixer browser queries
+- Corrected output for unhandled errors that get output when running "Report an issue" from the command `liveSass.command.createIssue`
+
+### Updates
+- `sass` from `1.30.0` to `1.32.4`
+  - Various changes, see their [changelog](https://github.com/sass/dart-sass/blob/master/CHANGELOG.md)
+- `autoprefixer` from `10.1.0` to `10.2.1`
+  - Fixed transition-property warnings (by @Sheraff).
+- Other, non-facing changes
+  - `eslint` from `7.16.0` to `7.17.0`
+  - `ts-loader` from `8.0.12` to `8.0.14`
+  - `postcss` from `8.2.1` to `8.2.4`
+  - `vscode-test` from `1.4.0` to `1.4.1`
+  - `webpack` from `5.11.0` to `5.14.0`
+  - `webpack-cli` from `4.2.0` to `4.3.0`
+
 ## [4.3.1] - 2021-01-09
 
 ### Fixed
@@ -131,7 +150,8 @@ All notable changes to this project will be documented in this file.
 
 
 
-[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.1...HEAD
+[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.2...HEAD
+[4.3.2]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.1...v4.3.2
 [4.3.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.0...v4.3.1
 [4.3.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.1.0...v4.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to this project will be documented in this file.
 ## [4.3.2] - 2021-01-15
 
 ### Fixed
-- Now handle errors caused by incorrect autoprfixer browser queries
+- Now handle errors caused by incorrect autoprefixer browser queries
 - Corrected output for unhandled errors that get output when running "Report an issue" from the command `liveSass.command.createIssue`
 
 ### Updates

--- a/README.md
+++ b/README.md
@@ -42,11 +42,19 @@ This extension has dependency on _[Live Server](https://marketplace.visualstudio
 - Output options are now only `expanded` and `compressed`
 - Only works on VS Code v1.50 and newer
 
-### 4.3.1 - 2021-01-09
+
+### 4.3.2 - 2021-01-15
 
 ### Fixed
-- Fixed [#10](https://github.com/glenn2223/vscode-live-sass-compiler/issues/10): Partial SASS files not triggering compilation of all files
-- Correction of output when running `liveSass.command.debugInclusion` and the file is excluded
+- Now handle errors caused by incorrect autoprfixer browser queries
+- Corrected output for unhandled errors that get output when running "Report an issue" from the command `liveSass.command.createIssue`
+
+### Updates
+- `sass` from `1.30.0` to `1.32.4`
+  - Various changes, see their [changelog](https://github.com/sass/dart-sass/blob/master/CHANGELOG.md)
+- `autoprefixer` from `10.1.0` to `10.2.1`
+  - Fixed transition-property warnings (by @Sheraff).
+- Other, non-facing changes. See changelog
 
 *See the full changelog [here](CHANGELOG.md).*
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This extension has dependency on _[Live Server](https://marketplace.visualstudio
 ### 4.3.2 - 2021-01-15
 
 ### Fixed
-- Now handle errors caused by incorrect autoprfixer browser queries
+- Now handle errors caused by incorrect autoprefixer browser queries
 - Corrected output for unhandled errors that get output when running "Report an issue" from the command `liveSass.command.createIssue`
 
 ### Updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -29,6 +29,12 @@
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
+        },
+        "@discoveryjs/json-ext": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
+            "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
+            "dev": true
         },
         "@eslint/eslintrc": {
             "version": "0.2.2",
@@ -97,44 +103,6 @@
                 "fastq": "^1.6.0"
             }
         },
-        "@types/autoprefixer": {
-            "version": "9.7.2",
-            "resolved": "https://registry.npmjs.org/@types/autoprefixer/-/autoprefixer-9.7.2.tgz",
-            "integrity": "sha512-QX7U7YW3zX3ex6MECtWO9folTGsXeP4b8bSjTq3I1ODM+H+sFHwGKuof+T+qBcDClGlCGtDb3SVfiTVfmcxw4g==",
-            "dev": true,
-            "requires": {
-                "@types/browserslist": "*",
-                "postcss": "7.x.x"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.35",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
-                    "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "@types/browserslist": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@types/browserslist/-/browserslist-4.8.0.tgz",
-            "integrity": "sha512-4PyO9OM08APvxxo1NmQyQKlJdowPCOQIy5D/NLO3aO0vGC57wsMptvGp3b8IbYnupFZr92l1dlVief1JvS6STQ==",
-            "dev": true
-        },
         "@types/eslint": {
             "version": "7.2.6",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
@@ -190,9 +158,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.14",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
-            "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==",
+            "version": "14.14.21",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.21.tgz",
+            "integrity": "sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A==",
             "dev": true
         },
         "@types/sass": {
@@ -211,20 +179,47 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.11.0.tgz",
-            "integrity": "sha512-x4arJMXBxyD6aBXLm3W7mSDZRiABzy+2PCLJbL7OPqlp53VXhaA1HKK7R2rTee5OlRhnUgnp8lZyVIqjnyPT6g==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.13.0.tgz",
+            "integrity": "sha512-ygqDUm+BUPvrr0jrXqoteMqmIaZ/bixYOc3A4BRwzEPTZPi6E+n44rzNZWaB0YvtukgP+aoj0i/fyx7FkM2p1w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.11.0",
-                "@typescript-eslint/scope-manager": "4.11.0",
+                "@typescript-eslint/experimental-utils": "4.13.0",
+                "@typescript-eslint/scope-manager": "4.13.0",
                 "debug": "^4.1.1",
                 "functional-red-black-tree": "^1.0.1",
+                "lodash": "^4.17.15",
                 "regexpp": "^3.0.0",
                 "semver": "^7.3.2",
                 "tsutils": "^3.17.1"
             },
             "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz",
+                    "integrity": "sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.13.0",
+                        "@typescript-eslint/visitor-keys": "4.13.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.13.0.tgz",
+                    "integrity": "sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==",
+                    "dev": true
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.13.0.tgz",
+                    "integrity": "sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.13.0",
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                },
                 "debug": {
                     "version": "4.3.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -243,28 +238,87 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.0.tgz",
-            "integrity": "sha512-1VC6mSbYwl1FguKt8OgPs8xxaJgtqFpjY/UzUYDBKq4pfQ5lBvN2WVeqYkzf7evW42axUHYl2jm9tNyFsb8oLg==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.13.0.tgz",
+            "integrity": "sha512-/ZsuWmqagOzNkx30VWYV3MNB/Re/CGv/7EzlqZo5RegBN8tMuPaBgNK6vPBCQA8tcYrbsrTdbx3ixMRRKEEGVw==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.11.0",
-                "@typescript-eslint/types": "4.11.0",
-                "@typescript-eslint/typescript-estree": "4.11.0",
+                "@typescript-eslint/scope-manager": "4.13.0",
+                "@typescript-eslint/types": "4.13.0",
+                "@typescript-eslint/typescript-estree": "4.13.0",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz",
+                    "integrity": "sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.13.0",
+                        "@typescript-eslint/visitor-keys": "4.13.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.13.0.tgz",
+                    "integrity": "sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.13.0.tgz",
+                    "integrity": "sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.13.0",
+                        "@typescript-eslint/visitor-keys": "4.13.0",
+                        "debug": "^4.1.1",
+                        "globby": "^11.0.1",
+                        "is-glob": "^4.0.1",
+                        "lodash": "^4.17.15",
+                        "semver": "^7.3.2",
+                        "tsutils": "^3.17.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "4.13.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.13.0.tgz",
+                    "integrity": "sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.13.0",
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.11.0.tgz",
-            "integrity": "sha512-NBTtKCC7ZtuxEV5CrHUO4Pg2s784pvavc3cnz6V+oJvVbK4tH9135f/RBP6eUA2KHiFKAollSrgSctQGmHbqJQ==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.13.0.tgz",
+            "integrity": "sha512-KO0J5SRF08pMXzq9+abyHnaGQgUJZ3Z3ax+pmqz9vl81JxmTTOUfQmq7/4awVfq09b6C4owNlOgOwp61pYRBSg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.11.0",
-                "@typescript-eslint/types": "4.11.0",
-                "@typescript-eslint/typescript-estree": "4.11.0",
+                "@typescript-eslint/scope-manager": "4.13.0",
+                "@typescript-eslint/types": "4.13.0",
+                "@typescript-eslint/typescript-estree": "4.13.0",
                 "debug": "^4.1.1"
             },
             "dependencies": {
@@ -286,29 +340,29 @@
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.0.tgz",
-            "integrity": "sha512-6VSTm/4vC2dHM3ySDW9Kl48en+yLNfVV6LECU8jodBHQOhO8adAVizaZ1fV0QGZnLQjQ/y0aBj5/KXPp2hBTjA==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.13.0.tgz",
+            "integrity": "sha512-UpK7YLG2JlTp/9G4CHe7GxOwd93RBf3aHO5L+pfjIrhtBvZjHKbMhBXTIQNkbz7HZ9XOe++yKrXutYm5KmjWgQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.11.0",
-                "@typescript-eslint/visitor-keys": "4.11.0"
+                "@typescript-eslint/types": "4.13.0",
+                "@typescript-eslint/visitor-keys": "4.13.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.0.tgz",
-            "integrity": "sha512-XXOdt/NPX++txOQHM1kUMgJUS43KSlXGdR/aDyEwuAEETwuPt02Nc7v+s57PzuSqMbNLclblQdv3YcWOdXhQ7g==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.13.0.tgz",
+            "integrity": "sha512-/+aPaq163oX+ObOG00M0t9tKkOgdv9lq0IQv/y4SqGkAXmhFmCfgsELV7kOCTb2vVU5VOmVwXBXJTDr353C1rQ==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.0.tgz",
-            "integrity": "sha512-eA6sT5dE5RHAFhtcC+b5WDlUIGwnO9b0yrfGa1mIOIAjqwSQCpXbLiFmKTdRbQN/xH2EZkGqqLDrKUuYOZ0+Hg==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.13.0.tgz",
+            "integrity": "sha512-9A0/DFZZLlGXn5XA349dWQFwPZxcyYyCFX5X88nWs2uachRDwGeyPz46oTsm9ZJE66EALvEns1lvBwa4d9QxMg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.11.0",
-                "@typescript-eslint/visitor-keys": "4.11.0",
+                "@typescript-eslint/types": "4.13.0",
+                "@typescript-eslint/visitor-keys": "4.13.0",
                 "debug": "^4.1.1",
                 "globby": "^11.0.1",
                 "is-glob": "^4.0.1",
@@ -335,12 +389,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.0.tgz",
-            "integrity": "sha512-tRYKyY0i7cMk6v4UIOCjl1LhuepC/pc6adQqJk4Is3YcC6k46HvsV9Wl7vQoLbm9qADgeujiT7KdLrylvFIQ+A==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.13.0.tgz",
+            "integrity": "sha512-6RoxWK05PAibukE7jElqAtNMq+RWZyqJ6Q/GdIxaiUj2Ept8jh8+FUVlbq9WxMYxkmEOPvCE5cRSyupMpwW31g==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.11.0",
+                "@typescript-eslint/types": "4.13.0",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -351,193 +405,164 @@
             "dev": true
         },
         "@webassemblyjs/ast": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.1.tgz",
-            "integrity": "sha512-uMu1nCWn2Wxyy126LlGqRVlhdTOsO/bsBRI4dNq3+6SiSuRKRQX6ejjKgh82LoGAPSq72lDUiQ4FWVaf0PecYw==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
+            "integrity": "sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/helper-module-context": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/wast-parser": "1.9.1"
+                "@webassemblyjs/helper-numbers": "1.11.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.0"
             }
         },
         "@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.1.tgz",
-            "integrity": "sha512-5VEKu024RySmLKTTBl9q1eO/2K5jk9ZS+2HXDBLA9s9p5IjkaXxWiDb/+b7wSQp6FRdLaH1IVGIfOex58Na2pg==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz",
+            "integrity": "sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==",
             "dev": true
         },
         "@webassemblyjs/helper-api-error": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.1.tgz",
-            "integrity": "sha512-y1lGmfm38djrScwpeL37rRR9f1D6sM8RhMpvM7CYLzOlHVboouZokXK/G88BpzW0NQBSvCCOnW5BFhten4FPfA==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz",
+            "integrity": "sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==",
             "dev": true
         },
         "@webassemblyjs/helper-buffer": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.1.tgz",
-            "integrity": "sha512-uS6VSgieHbk/m4GSkMU5cqe/5TekdCzQso4revCIEQ3vpGZgqSSExi4jWpTWwDpAHOIAb1Jfrs0gUB9AA4n71w==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz",
+            "integrity": "sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==",
             "dev": true
         },
-        "@webassemblyjs/helper-code-frame": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.1.tgz",
-            "integrity": "sha512-ZQ2ZT6Evk4DPIfD+92AraGYaFIqGm4U20e7FpXwl7WUo2Pn1mZ1v8VGH8i+Y++IQpxPbQo/UyG0Khs7eInskzA==",
+        "@webassemblyjs/helper-numbers": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz",
+            "integrity": "sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/wast-printer": "1.9.1"
-            }
-        },
-        "@webassemblyjs/helper-fsm": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.1.tgz",
-            "integrity": "sha512-J32HGpveEqqcKFS0YbgicB0zAlpfIxJa5MjxDxhu3i5ltPcVfY5EPvKQ1suRguFPehxiUs+/hfkwPEXom/l0lw==",
-            "dev": true
-        },
-        "@webassemblyjs/helper-module-context": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.1.tgz",
-            "integrity": "sha512-IEH2cMmEQKt7fqelLWB5e/cMdZXf2rST1JIrzWmf4XBt3QTxGdnnLvV4DYoN8pJjOx0VYXsWg+yF16MmJtolZg==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.9.1"
+                "@webassemblyjs/floating-point-hex-parser": "1.11.0",
+                "@webassemblyjs/helper-api-error": "1.11.0",
+                "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.1.tgz",
-            "integrity": "sha512-i2rGTBqFUcSXxyjt2K4vm/3kkHwyzG6o427iCjcIKjOqpWH8SEem+xe82jUk1iydJO250/CvE5o7hzNAMZf0dQ==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz",
+            "integrity": "sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==",
             "dev": true
         },
         "@webassemblyjs/helper-wasm-section": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.1.tgz",
-            "integrity": "sha512-FetqzjtXZr2d57IECK+aId3D0IcGweeM0CbAnJHkYJkcRTHP+YcMb7Wmc0j21h5UWBpwYGb9dSkK/93SRCTrGg==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz",
+            "integrity": "sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1"
+                "@webassemblyjs/ast": "1.11.0",
+                "@webassemblyjs/helper-buffer": "1.11.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
+                "@webassemblyjs/wasm-gen": "1.11.0"
             }
         },
         "@webassemblyjs/ieee754": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.1.tgz",
-            "integrity": "sha512-EvTG9M78zP1MmkBpUjGQHZc26DzPGZSLIPxYHCjQsBMo60Qy2W34qf8z0exRDtxBbRIoiKa5dFyWer/7r1aaSQ==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz",
+            "integrity": "sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==",
             "dev": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.1.tgz",
-            "integrity": "sha512-Oc04ub0vFfLnF+2/+ki3AE+anmW4sv9uNBqb+79fgTaPv6xJsOT0dhphNfL3FrME84CbX/D1T9XT8tjFo0IIiw==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.0.tgz",
+            "integrity": "sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==",
             "dev": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/utf8": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.1.tgz",
-            "integrity": "sha512-llkYtppagjCodFjo0alWOUhAkfOiQPQDIc5oA6C9sFAXz7vC9QhZf/f8ijQIX+A9ToM3c9Pq85X0EX7nx9gVhg==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.0.tgz",
+            "integrity": "sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==",
             "dev": true
         },
         "@webassemblyjs/wasm-edit": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.1.tgz",
-            "integrity": "sha512-S2IaD6+x9B2Xi8BCT0eGsrXXd8UxAh2LVJpg1ZMtHXnrDcsTtIX2bDjHi40Hio6Lc62dWHmKdvksI+MClCYbbw==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz",
+            "integrity": "sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/helper-wasm-section": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1",
-                "@webassemblyjs/wasm-opt": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1",
-                "@webassemblyjs/wast-printer": "1.9.1"
+                "@webassemblyjs/ast": "1.11.0",
+                "@webassemblyjs/helper-buffer": "1.11.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
+                "@webassemblyjs/helper-wasm-section": "1.11.0",
+                "@webassemblyjs/wasm-gen": "1.11.0",
+                "@webassemblyjs/wasm-opt": "1.11.0",
+                "@webassemblyjs/wasm-parser": "1.11.0",
+                "@webassemblyjs/wast-printer": "1.11.0"
             }
         },
         "@webassemblyjs/wasm-gen": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.1.tgz",
-            "integrity": "sha512-bqWI0S4lBQsEN5FTZ35vYzfKUJvtjNnBobB1agCALH30xNk1LToZ7Z8eiaR/Z5iVECTlBndoRQV3F6mbEqE/fg==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz",
+            "integrity": "sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/ieee754": "1.9.1",
-                "@webassemblyjs/leb128": "1.9.1",
-                "@webassemblyjs/utf8": "1.9.1"
+                "@webassemblyjs/ast": "1.11.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
+                "@webassemblyjs/ieee754": "1.11.0",
+                "@webassemblyjs/leb128": "1.11.0",
+                "@webassemblyjs/utf8": "1.11.0"
             }
         },
         "@webassemblyjs/wasm-opt": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.1.tgz",
-            "integrity": "sha512-gSf7I7YWVXZ5c6XqTEqkZjVs8K1kc1k57vsB6KBQscSagDNbAdxt6MwuJoMjsE1yWY1tsuL+pga268A6u+Fdkg==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz",
+            "integrity": "sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-buffer": "1.9.1",
-                "@webassemblyjs/wasm-gen": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1"
+                "@webassemblyjs/ast": "1.11.0",
+                "@webassemblyjs/helper-buffer": "1.11.0",
+                "@webassemblyjs/wasm-gen": "1.11.0",
+                "@webassemblyjs/wasm-parser": "1.11.0"
             }
         },
         "@webassemblyjs/wasm-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.1.tgz",
-            "integrity": "sha512-ImM4N2T1MEIond0MyE3rXvStVxEmivQrDKf/ggfh5pP6EHu3lL/YTAoSrR7shrbKNPpeKpGesW1LIK/L4kqduw==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz",
+            "integrity": "sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-api-error": "1.9.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.9.1",
-                "@webassemblyjs/ieee754": "1.9.1",
-                "@webassemblyjs/leb128": "1.9.1",
-                "@webassemblyjs/utf8": "1.9.1"
-            }
-        },
-        "@webassemblyjs/wast-parser": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.1.tgz",
-            "integrity": "sha512-2xVxejXSvj3ls/o2TR/zI6p28qsGupjHhnHL6URULQRcXmryn3w7G83jQMcT7PHqUfyle65fZtWLukfdLdE7qw==",
-            "dev": true,
-            "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/floating-point-hex-parser": "1.9.1",
-                "@webassemblyjs/helper-api-error": "1.9.1",
-                "@webassemblyjs/helper-code-frame": "1.9.1",
-                "@webassemblyjs/helper-fsm": "1.9.1",
-                "@xtuc/long": "4.2.2"
+                "@webassemblyjs/ast": "1.11.0",
+                "@webassemblyjs/helper-api-error": "1.11.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.0",
+                "@webassemblyjs/ieee754": "1.11.0",
+                "@webassemblyjs/leb128": "1.11.0",
+                "@webassemblyjs/utf8": "1.11.0"
             }
         },
         "@webassemblyjs/wast-printer": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.1.tgz",
-            "integrity": "sha512-tDV8V15wm7mmbAH6XvQRU1X+oPGmeOzYsd6h7hlRLz6QpV4Ec/KKxM8OpLtFmQPLCreGxTp+HuxtH4pRIZyL9w==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz",
+            "integrity": "sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/wast-parser": "1.9.1",
+                "@webassemblyjs/ast": "1.11.0",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webpack-cli/info": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.1.0.tgz",
-            "integrity": "sha512-uNWSdaYHc+f3LdIZNwhdhkjjLDDl3jP2+XBqAq9H8DjrJUvlOKdP8TNruy1yEaDfgpAIgbSAN7pye4FEHg9tYQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.2.1.tgz",
+            "integrity": "sha512-fLnDML5HZ5AEKzHul8xLAksoKN2cibu6MgonkUj8R9V7bbeVRkd1XbGEGWrAUNYHbX1jcqCsDEpBviE5StPMzQ==",
             "dev": true,
             "requires": {
                 "envinfo": "^7.7.3"
             }
         },
         "@webpack-cli/serve": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.1.0.tgz",
-            "integrity": "sha512-7RfnMXCpJ/NThrhq4gYQYILB18xWyoQcBey81oIyVbmgbc6m5ZHHyFK+DyH7pLHJf0p14MxL4mTsoPAgBSTpIg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.2.1.tgz",
+            "integrity": "sha512-Zj1z6AyS+vqV6Hfi7ngCjFGdHV5EwZNIHo6QfFTNe9PyW+zBU1zJ9BiOW1pmUEq950RC4+Dym6flyA/61/vhyw==",
             "dev": true
         },
         "@xtuc/ieee754": {
@@ -630,12 +655,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "array-back": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-            "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
-            "dev": true
-        },
         "array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -649,44 +668,44 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.1.0.tgz",
-            "integrity": "sha512-0/lBNwN+ZUnb5su18NZo5MBIjDaq6boQKZcxwy86Gip/CmXA2zZqUoFQLCNAGI5P25ZWSP2RWdhDJ8osfKEjoQ==",
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.1.tgz",
+            "integrity": "sha512-dwP0UjyYvROUvtU+boBx8ff5pPWami1NGTrJs9YUsS/oZVbRAcdNHOOuXSA1fc46tgKqe072cVaKD69rvCc3QQ==",
             "requires": {
-                "browserslist": "^4.15.0",
-                "caniuse-lite": "^1.0.30001165",
+                "browserslist": "^4.16.1",
+                "caniuse-lite": "^1.0.30001173",
                 "colorette": "^1.2.1",
-                "fraction.js": "^4.0.12",
+                "fraction.js": "^4.0.13",
                 "normalize-range": "^0.1.2",
                 "postcss-value-parser": "^4.1.0"
             },
             "dependencies": {
                 "browserslist": {
-                    "version": "4.16.0",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
-                    "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
+                    "version": "4.16.1",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
+                    "integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
                     "requires": {
-                        "caniuse-lite": "^1.0.30001165",
+                        "caniuse-lite": "^1.0.30001173",
                         "colorette": "^1.2.1",
-                        "electron-to-chromium": "^1.3.621",
+                        "electron-to-chromium": "^1.3.634",
                         "escalade": "^3.1.1",
-                        "node-releases": "^1.1.67"
+                        "node-releases": "^1.1.69"
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001170",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz",
-                    "integrity": "sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA=="
+                    "version": "1.0.30001177",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz",
+                    "integrity": "sha512-6Ld7t3ifCL02jTj3MxPMM5wAYjbo4h/TAQGFTgv1inihP1tWnWp8mxxT4ut4JBEHLbpFXEXJJQ119JCJTBkYDw=="
                 },
                 "electron-to-chromium": {
-                    "version": "1.3.629",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.629.tgz",
-                    "integrity": "sha512-iSPPJtPvHrMAvYOt+9cdbDmTasPqwnwz4lkP8Dn200gDNUBQOLQ96xUsWXBwXslAo5XxdoXAoQQ3RAy4uao9IQ=="
+                    "version": "1.3.639",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.639.tgz",
+                    "integrity": "sha512-bwl6/U6xb3d3CNufQU9QeO1L32ueouFwW4bWANSwdXR7LVqyLzWjNbynoKNfuC38QFB5Qn7O0l2KLqBkcXnC3Q=="
                 },
                 "node-releases": {
-                    "version": "1.1.67",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-                    "integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg=="
+                    "version": "1.1.69",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
+                    "integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA=="
                 }
             }
         },
@@ -730,15 +749,16 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.14.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.5.tgz",
-            "integrity": "sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==",
+            "version": "4.16.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
+            "integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001135",
-                "electron-to-chromium": "^1.3.571",
-                "escalade": "^3.1.0",
-                "node-releases": "^1.1.61"
+                "caniuse-lite": "^1.0.30001173",
+                "colorette": "^1.2.1",
+                "electron-to-chromium": "^1.3.634",
+                "escalade": "^3.1.1",
+                "node-releases": "^1.1.69"
             }
         },
         "buffer-from": {
@@ -760,9 +780,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001148",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-            "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
+            "version": "1.0.30001177",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001177.tgz",
+            "integrity": "sha512-6Ld7t3ifCL02jTj3MxPMM5wAYjbo4h/TAQGFTgv1inihP1tWnWp8mxxT4ut4JBEHLbpFXEXJJQ119JCJTBkYDw==",
             "dev": true
         },
         "chalk": {
@@ -788,18 +808,26 @@
             }
         },
         "chokidar": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-            "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.0.tgz",
+            "integrity": "sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==",
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.1",
+                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
-                "readdirp": "~3.2.0"
+                "readdirp": "~3.5.0"
+            },
+            "dependencies": {
+                "fsevents": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+                    "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+                    "optional": true
+                }
             }
         },
         "chrome-trace-event": {
@@ -870,18 +898,6 @@
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
             "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
         },
-        "command-line-usage": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
-            "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
-            "dev": true,
-            "requires": {
-                "array-back": "^4.0.1",
-                "chalk": "^2.4.2",
-                "table-layout": "^1.0.1",
-                "typical": "^5.2.0"
-            }
-        },
         "commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -922,24 +938,18 @@
             }
         },
         "debug": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "dev": true,
             "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.0.0"
             }
         },
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-            "dev": true
-        },
-        "deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true
         },
         "deep-is": {
@@ -973,9 +983,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.582",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.582.tgz",
-            "integrity": "sha512-0nCJ7cSqnkMC+kUuPs0YgklFHraWGl/xHqtZWWtOeVtyi+YqkoAOMGuZQad43DscXCQI/yizcTa3u6B5r+BLww==",
+            "version": "1.3.639",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.639.tgz",
+            "integrity": "sha512-bwl6/U6xb3d3CNufQU9QeO1L32ueouFwW4bWANSwdXR7LVqyLzWjNbynoKNfuC38QFB5Qn7O0l2KLqBkcXnC3Q==",
             "dev": true
         },
         "emoji-regex": {
@@ -990,23 +1000,14 @@
             "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
             "dev": true
         },
-        "end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dev": true,
-            "requires": {
-                "once": "^1.4.0"
-            }
-        },
         "enhanced-resolve": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz",
-            "integrity": "sha512-ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
+            "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.0.0"
+                "tapable": "^2.2.0"
             }
         },
         "enquirer": {
@@ -1041,6 +1042,12 @@
                 "prr": "~1.0.1"
             }
         },
+        "es-module-lexer": {
+            "version": "0.3.26",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
+            "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
+            "dev": true
+        },
         "es6-promise": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -1068,9 +1075,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.16.0.tgz",
-            "integrity": "sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
+            "integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -1301,19 +1308,19 @@
             "dev": true
         },
         "execa": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-            "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+            "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^7.0.0",
-                "get-stream": "^5.0.0",
-                "human-signals": "^1.1.1",
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
                 "is-stream": "^2.0.0",
                 "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.0",
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
                 "strip-final-newline": "^2.0.0"
             }
         },
@@ -1347,6 +1354,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fastest-levenshtein": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+            "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
             "dev": true
         },
         "fastq": {
@@ -1419,9 +1432,9 @@
             "dev": true
         },
         "fraction.js": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.12.tgz",
-            "integrity": "sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA=="
+            "version": "4.0.13",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
+            "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA=="
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -1432,6 +1445,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
             "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+            "dev": true,
             "optional": true
         },
         "function-bind": {
@@ -1453,13 +1467,10 @@
             "dev": true
         },
         "get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-            "dev": true,
-            "requires": {
-                "pump": "^3.0.0"
-            }
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+            "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+            "dev": true
         },
         "glob": {
             "version": "7.1.6",
@@ -1562,23 +1573,6 @@
             "requires": {
                 "agent-base": "4",
                 "debug": "3.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
             }
         },
         "https-proxy-agent": {
@@ -1592,9 +1586,9 @@
             }
         },
         "human-signals": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
         },
         "ignore": {
@@ -1658,12 +1652,6 @@
                     "requires": {
                         "p-limit": "^2.2.0"
                     }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                    "dev": true
                 },
                 "pkg-dir": {
                     "version": "4.2.0",
@@ -1776,23 +1764,6 @@
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^7.0.0"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
             }
         },
         "js-tokens": {
@@ -1830,19 +1801,13 @@
             "dev": true
         },
         "json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+            "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
             "dev": true,
             "requires": {
-                "minimist": "^1.2.0"
+                "minimist": "^1.2.5"
             }
-        },
-        "leven": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-            "dev": true
         },
         "levn": {
             "version": "0.4.1",
@@ -1855,20 +1820,20 @@
             }
         },
         "loader-runner": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.1.0.tgz",
-            "integrity": "sha512-oR4lB4WvwFoC70ocraKhn5nkKSs23t57h9udUgw8o0iH8hMXeEoRuUgfcvgUwAJ1ZpRqBvcou4N2SMvM1DwMrA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+            "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
             "dev": true
         },
         "loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
             "dev": true,
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
+                "json5": "^2.1.2"
             }
         },
         "locate-path": {
@@ -1973,18 +1938,18 @@
             }
         },
         "mime-db": {
-            "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+            "version": "1.45.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+            "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.27",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+            "version": "2.1.28",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+            "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.44.0"
+                "mime-db": "1.45.0"
             }
         },
         "mimic-fn": {
@@ -2096,9 +2061,9 @@
             }
         },
         "ms": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
         "nanoid": {
@@ -2119,9 +2084,9 @@
             "dev": true
         },
         "node-releases": {
-            "version": "1.1.64",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.64.tgz",
-            "integrity": "sha512-Iec8O9166/x2HRMJyLLLWkd0sFFLrFNy+Xf+JQfSQsdBJzPcHpNl3JQ9gD4j+aJxmCa25jNsIbM4bmACtSbkSg==",
+            "version": "1.1.69",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
+            "integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==",
             "dev": true
         },
         "normalize-path": {
@@ -2259,57 +2224,12 @@
             "dev": true,
             "requires": {
                 "find-up": "^5.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-                    "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^6.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "locate-path": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-                    "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^5.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-                    "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-                    "dev": true,
-                    "requires": {
-                        "yocto-queue": "^0.1.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-                    "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^3.0.2"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-                    "dev": true
-                }
             }
         },
         "postcss": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.1.tgz",
-            "integrity": "sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==",
+            "version": "8.2.4",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.4.tgz",
+            "integrity": "sha512-kRFftRoExRVXZlwUuay9iC824qmXPcQQVzAjbCCgjpXnkdMCJYBu2gTwAaFBzv8ewND6O8xFb3aELmEkh9zTzg==",
             "requires": {
                 "colorette": "^1.2.1",
                 "nanoid": "^3.1.20",
@@ -2344,16 +2264,6 @@
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
             "dev": true
-        },
-        "pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dev": true,
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
         },
         "punycode": {
             "version": "2.1.1",
@@ -2394,11 +2304,11 @@
             }
         },
         "readdirp": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-            "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
             "requires": {
-                "picomatch": "^2.0.4"
+                "picomatch": "^2.2.1"
             }
         },
         "rechoir": {
@@ -2410,12 +2320,6 @@
                 "resolve": "^1.9.0"
             }
         },
-        "reduce-flatten": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-            "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-            "dev": true
-        },
         "regexpp": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -2426,6 +2330,12 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true
         },
         "require-main-filename": {
@@ -2487,9 +2397,9 @@
             "dev": true
         },
         "sass": {
-            "version": "1.30.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.30.0.tgz",
-            "integrity": "sha512-26EUhOXRLaUY7+mWuRFqGeGGNmhB1vblpTENO1Z7mAzzIZeVxZr9EZoaY1kyGLFWdSOZxRMAufiN2mkbO6dAlw==",
+            "version": "1.32.4",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.4.tgz",
+            "integrity": "sha512-N0BT0PI/t3+gD8jKa83zJJUb7ssfQnRRfqN+GIErokW6U4guBpfYl8qYB+OFLEho+QvnV5ZH1R9qhUC/Z2Ch9w==",
             "requires": {
                 "chokidar": ">=2.0.0 <4.0.0"
             }
@@ -2692,17 +2602,29 @@
             }
         },
         "table": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.0.4.tgz",
-            "integrity": "sha512-sBT4xRLdALd+NFBvwOz8bw4b15htyythha+q+DVZqy2RS08PPC8O2sZFgJYEY7bJvbCFKccs+WIZ/cd+xxTWCw==",
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
+            "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
             "dev": true,
             "requires": {
-                "ajv": "^6.12.4",
+                "ajv": "^7.0.2",
                 "lodash": "^4.17.20",
                 "slice-ansi": "^4.0.0",
                 "string-width": "^4.2.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+                    "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "ansi-regex": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -2719,6 +2641,12 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
                     "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
                     "dev": true
                 },
                 "string-width": {
@@ -2741,18 +2669,6 @@
                         "ansi-regex": "^5.0.0"
                     }
                 }
-            }
-        },
-        "table-layout": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
-            "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
-            "dev": true,
-            "requires": {
-                "array-back": "^4.0.1",
-                "deep-extend": "~0.6.0",
-                "typical": "^5.2.0",
-                "wordwrapjs": "^4.0.0"
             }
         },
         "tapable": {
@@ -2781,17 +2697,17 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz",
-            "integrity": "sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz",
+            "integrity": "sha512-5XNNXZiR8YO6X6KhSGXfY0QrGrCRlSwAEjIIrlRQR4W8nP69TaJUlh3bkuac6zzgspiGPfKEHcY295MMVExl5Q==",
             "dev": true,
             "requires": {
-                "jest-worker": "^26.6.1",
-                "p-limit": "^3.0.2",
+                "jest-worker": "^26.6.2",
+                "p-limit": "^3.1.0",
                 "schema-utils": "^3.0.0",
                 "serialize-javascript": "^5.0.1",
                 "source-map": "^0.6.1",
-                "terser": "^5.3.8"
+                "terser": "^5.5.1"
             },
             "dependencies": {
                 "p-limit": {
@@ -2820,34 +2736,62 @@
             }
         },
         "ts-loader": {
-            "version": "8.0.12",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.12.tgz",
-            "integrity": "sha512-UIivVfGVJDdwwjgSrbtcL9Nf10c1BWnL1mxAQUVcnhNIn/P9W3nP5v60Z0aBMtc7ZrE11lMmU6+5jSgAXmGaYw==",
+            "version": "8.0.14",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.14.tgz",
+            "integrity": "sha512-Jt/hHlUnApOZjnSjTmZ+AbD5BGlQFx3f1D0nYuNKwz0JJnuDGHJas6az+FlWKwwRTu+26GXpv249A8UAnYUpqA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.0",
+                "chalk": "^4.1.0",
                 "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.0.2",
+                "loader-utils": "^2.0.0",
                 "micromatch": "^4.0.0",
-                "semver": "^6.0.0"
+                "semver": "^7.3.4"
             },
             "dependencies": {
-                "enhanced-resolve": {
+                "ansi-styles": {
                     "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-                    "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "enhanced-resolve": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+                    "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "memory-fs": "^0.5.0",
                         "tapable": "^1.0.0"
                     }
-                },
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
                 },
                 "tapable": {
                     "version": "1.1.3",
@@ -2893,12 +2837,6 @@
             "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
             "dev": true
         },
-        "typical": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-            "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-            "dev": true
-        },
         "uri-js": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
@@ -2921,9 +2859,9 @@
             "dev": true
         },
         "vscode-test": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.0.tgz",
-            "integrity": "sha512-Jt7HNGvSE0+++Tvtq5wc4hiXLIr2OjDShz/gbAfM/mahQpy4rKBnmOK33D+MR67ATWviQhl+vpmU3p/qwSH/Pg==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.1.tgz",
+            "integrity": "sha512-Ls7+JyC06cUCuomlTYk4aNJI00Rri09hgtkNl3zfQ1bj6meXglpSPpuzJ/RPNetlUHFMm4eGs0Xr/H5pFPVwfQ==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^2.1.0",
@@ -2942,53 +2880,53 @@
             }
         },
         "webpack": {
-            "version": "5.11.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.11.0.tgz",
-            "integrity": "sha512-ubWv7iP54RqAC/VjixgpnLLogCFbAfSOREcSWnnOlZEU8GICC5eKmJSu6YEnph2N2amKqY9rvxSwgyHxVqpaRw==",
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.14.0.tgz",
+            "integrity": "sha512-PFtfqXIKT6EG+k4L7d9whUPacN2XvxlUMc8NAQvN+sF9G8xPQqrCDGDiXbAdyGNz+/OP6ioxnUKybBBZ1kp/2A==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
                 "@types/estree": "^0.0.45",
-                "@webassemblyjs/ast": "1.9.1",
-                "@webassemblyjs/helper-module-context": "1.9.1",
-                "@webassemblyjs/wasm-edit": "1.9.1",
-                "@webassemblyjs/wasm-parser": "1.9.1",
+                "@webassemblyjs/ast": "1.11.0",
+                "@webassemblyjs/wasm-edit": "1.11.0",
+                "@webassemblyjs/wasm-parser": "1.11.0",
                 "acorn": "^8.0.4",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.3.1",
+                "enhanced-resolve": "^5.7.0",
+                "es-module-lexer": "^0.3.26",
                 "eslint-scope": "^5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.4",
                 "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^4.1.0",
+                "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "pkg-dir": "^5.0.0",
                 "schema-utils": "^3.0.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.0.3",
+                "terser-webpack-plugin": "^5.1.1",
                 "watchpack": "^2.0.0",
                 "webpack-sources": "^2.1.1"
             }
         },
         "webpack-cli": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.2.0.tgz",
-            "integrity": "sha512-EIl3k88vaF4fSxWSgtAQR+VwicfLMTZ9amQtqS4o+TDPW9HGaEpbFBbAZ4A3ZOT5SOnMxNOzROsSTPiE8tBJPA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.3.1.tgz",
+            "integrity": "sha512-/F4+9QNZM/qKzzL9/06Am8NXIkGV+/NqQ62Dx7DSqudxxpAgBqYn6V7+zp+0Y7JuWksKUbczRY3wMTd+7Uj6OA==",
             "dev": true,
             "requires": {
-                "@webpack-cli/info": "^1.1.0",
-                "@webpack-cli/serve": "^1.1.0",
+                "@discoveryjs/json-ext": "^0.5.0",
+                "@webpack-cli/info": "^1.2.1",
+                "@webpack-cli/serve": "^1.2.1",
                 "colorette": "^1.2.1",
-                "command-line-usage": "^6.1.0",
                 "commander": "^6.2.0",
                 "enquirer": "^2.3.6",
-                "execa": "^4.1.0",
+                "execa": "^5.0.0",
+                "fastest-levenshtein": "^1.0.12",
                 "import-local": "^3.0.2",
                 "interpret": "^2.2.0",
-                "leven": "^3.1.0",
                 "rechoir": "^0.7.0",
                 "v8-compile-cache": "^2.2.0",
                 "webpack-merge": "^4.2.2"
@@ -3050,16 +2988,6 @@
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true
-        },
-        "wordwrapjs": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
-            "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
-            "dev": true,
-            "requires": {
-                "reduce-flatten": "^2.0.0",
-                "typical": "^5.0.0"
-            }
         },
         "workerpool": {
             "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime with live browser reload.",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -221,30 +221,29 @@
         "lint": "eslint -c .eslintrc.js --ext .ts ./src/"
     },
     "dependencies": {
-        "autoprefixer": "^10.1.0",
+        "autoprefixer": "^10.2.1",
         "glob": "^7.1.6",
-        "postcss": "^8.2.1",
-        "sass": "^1.30.0"
+        "postcss": "^8.2.4",
+        "sass": "^1.32.4"
     },
     "devDependencies": {
-        "@types/autoprefixer": "^9.7.2",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.0",
-        "@types/node": "^14.14.14",
+        "@types/node": "^14.14.21",
         "@types/sass": "^1.16.0",
         "@types/vscode": "^1.50.0",
-        "@typescript-eslint/eslint-plugin": "^4.11.0",
-        "@typescript-eslint/parser": "^4.11.0",
-        "eslint": "^7.16.0",
+        "@typescript-eslint/eslint-plugin": "^4.13.0",
+        "@typescript-eslint/parser": "^4.13.0",
+        "eslint": "^7.17.0",
         "mocha": "^8.2.0",
-        "ts-loader": "^8.0.12",
+        "ts-loader": "^8.0.14",
         "typescript": "^4.1.3",
-        "vscode-test": "^1.4.0",
-        "webpack": "^5.11.0",
-        "webpack-cli": "^4.2.0"
+        "vscode-test": "^1.4.1",
+        "webpack": "^5.14.0",
+        "webpack-cli": "^4.3.1"
     },
     "announcement": {
-        "onVersion": "4.3.1",
-        "message": "SassCompiler v4.3.1: Bug fix for partial files not processing all files"
+        "onVersion": "4.3.2",
+        "message": "SassCompiler v4.3.2: Updates (including sass@1.32.4). Improved error handling (autoprefix & `Report an issue` command)"
     }
 }

--- a/src/StatusbarUi.ts
+++ b/src/StatusbarUi.ts
@@ -5,7 +5,10 @@ export class StatusBarUi {
 
     private static get statusBarItem() {
         if (!StatusBarUi._statusBarItem) {
-            StatusBarUi._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 200);
+            StatusBarUi._statusBarItem = vscode.window.createStatusBarItem(
+                vscode.StatusBarAlignment.Right,
+                200
+            );
             this.statusBarItem.show();
         }
 
@@ -34,7 +37,10 @@ export class StatusBarUi {
     }
 
     static working(workingMsg = "Working on it..."): void {
-        this.customMessage(workingMsg, "In case it takes a long time, show output window and report.");
+        this.customMessage(
+            workingMsg,
+            "In case it takes a long time, show output window and report."
+        );
     }
 
     static customMessage(text: string, tooltip: string, iconName = "pulse"): void {

--- a/src/VscodeExtensions.ts
+++ b/src/VscodeExtensions.ts
@@ -50,7 +50,7 @@ export class ErrorLogger {
                 "",
                 `**LOG**: ${lastError === null ? "" : lastError.createdAt.toISOString().replace("T", " ")}`,
                 "```JSON",
-                lastError === null ? '{\n"NO LOG": "PLEASE SPECIFY YOUR ISSUE BELOW"\n}' : lastError,
+                lastError === null ? '{\n"NO LOG": "PLEASE SPECIFY YOUR ISSUE BELOW"\n}' : JSON.stringify(lastError, null, 4),
                 "```",
                 "=======================",
                 "<!-- You can add any supporting information below here -->\n",

--- a/src/VscodeExtensions.ts
+++ b/src/VscodeExtensions.ts
@@ -40,7 +40,9 @@ export class ErrorLogger {
                 `| VS Code | v${version} |`,
                 `| Platform | ${process.platform} ${process.arch} |`,
                 `| Node | ${process.versions.node} (${process.versions.modules}) |`,
-                `| Live Sass | ${extensions.getExtension("glenn2223.live-sass").packageJSON.version} |`,
+                `| Live Sass | ${
+                    extensions.getExtension("glenn2223.live-sass").packageJSON.version
+                } |`,
                 `<details><summary>Installed Extensions</summary><div>`,
                 extensions.all
                     .filter((ext) => ext.isActive)
@@ -48,9 +50,13 @@ export class ErrorLogger {
                     .join("<br/>"),
                 "</div></details>",
                 "",
-                `**LOG**: ${lastError === null ? "" : lastError.createdAt.toISOString().replace("T", " ")}`,
+                `**LOG**: ${
+                    lastError === null ? "" : lastError.createdAt.toISOString().replace("T", " ")
+                }`,
                 "```JSON",
-                lastError === null ? '{\n"NO LOG": "PLEASE SPECIFY YOUR ISSUE BELOW"\n}' : JSON.stringify(lastError, null, 4),
+                lastError === null
+                    ? '{\n"NO LOG": "PLEASE SPECIFY YOUR ISSUE BELOW"\n}'
+                    : JSON.stringify(lastError, null, 4),
                 "```",
                 "=======================",
                 "<!-- You can add any supporting information below here -->\n",
@@ -104,7 +110,12 @@ export class OutputWindow {
         return OutputWindow._msgChannel;
     }
 
-    static Show(msgHeadline: string, MsgBody: string[], popUpToUI = false, addEndLine = true): void {
+    static Show(
+        msgHeadline: string,
+        MsgBody: string[],
+        popUpToUI = false,
+        addEndLine = true
+    ): void {
         if (msgHeadline) {
             OutputWindow.MsgChannel.appendLine(msgHeadline);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,12 +14,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
         checkNewAnnouncement(context.globalState);
 
-        const disposablecompileAll = vscode.commands.registerCommand("liveSass.command.watchMySass", () => {
-                appModel.StartWatching();
-            }),
-            disposableStopWaching = vscode.commands.registerCommand("liveSass.command.donotWatchMySass", () => {
-                appModel.StopWatching();
-            }),
+        const disposablecompileAll = vscode.commands.registerCommand(
+                "liveSass.command.watchMySass",
+                () => {
+                    appModel.StartWatching();
+                }
+            ),
+            disposableStopWaching = vscode.commands.registerCommand(
+                "liveSass.command.donotWatchMySass",
+                () => {
+                    appModel.StopWatching();
+                }
+            ),
             disposableOneTimeCompileSass = vscode.commands.registerCommand(
                 "liveSass.command.oneTimeCompileSass",
                 () => {
@@ -32,18 +38,30 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                     appModel.compileCurrentFile();
                 }
             ),
-            disposableOpenOutputWindow = vscode.commands.registerCommand("liveSass.command.openOutputWindow", () => {
-                appModel.openOutputWindow();
-            }),
-            disposableCreateIssue = vscode.commands.registerCommand("liveSass.command.createIssue", () => {
-                appModel.createIssue();
-            }),
-            disposableDebugInclusion = vscode.commands.registerCommand("liveSass.command.debugInclusion", async () => {
-                await appModel.debugInclusion();
-            }),
-            disposableDebugFileList = vscode.commands.registerCommand("liveSass.command.debugFileList", async () => {
-                appModel.debugFileList();
-            }),
+            disposableOpenOutputWindow = vscode.commands.registerCommand(
+                "liveSass.command.openOutputWindow",
+                () => {
+                    appModel.openOutputWindow();
+                }
+            ),
+            disposableCreateIssue = vscode.commands.registerCommand(
+                "liveSass.command.createIssue",
+                () => {
+                    appModel.createIssue();
+                }
+            ),
+            disposableDebugInclusion = vscode.commands.registerCommand(
+                "liveSass.command.debugInclusion",
+                async () => {
+                    await appModel.debugInclusion();
+                }
+            ),
+            disposableDebugFileList = vscode.commands.registerCommand(
+                "liveSass.command.debugFileList",
+                async () => {
+                    appModel.debugFileList();
+                }
+            ),
             disposableOnDidSave = vscode.workspace.onDidSaveTextDocument(() => {
                 appModel.compileOnSave();
             });


### PR DESCRIPTION
## 4.3.2 - 2021-01-15

### Fixed
- Now handle errors caused by incorrect autoprefixer browser queries
- Corrected output for unhandled errors that get output when running "Report an issue" from the command `liveSass.command.createIssue`

### Updates
- `sass` from `1.30.0` to `1.32.4`
  - Various changes, see their [changelog](https://github.com/sass/dart-sass/blob/master/CHANGELOG.md)
- `autoprefixer` from `10.1.0` to `10.2.1`
  - Fixed transition-property warnings (by @Sheraff).
- Other, non-facing changes
  - `eslint` from `7.16.0` to `7.17.0`
  - `ts-loader` from `8.0.12` to `8.0.14`
  - `postcss` from `8.2.1` to `8.2.4`
  - `vscode-test` from `1.4.0` to `1.4.1`
  - `webpack` from `5.11.0` to `5.14.0`
  - `webpack-cli` from `4.2.0` to `4.3.0`