### PR TITLE
v4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.3.3] - 2021-01-18
+
+### Fixed
+- Fixed [#15](https://github.com/glenn2223/vscode-live-sass-compiler/issues/15): No longer outputs absolute path in map file and map link in css output
+- Reinstated feature of partial files being checked for exclusion
+- Autoprefixer map lines now relate to actual SASS files rather than the css file generated
+- When there's an include list, a non partial file that's not "included" would still be processed
+- Now gets the correct list of included partial files
+
 ## [4.3.2] - 2021-01-15
 
 ### Fixed
@@ -150,7 +159,8 @@ All notable changes to this project will be documented in this file.
 
 
 
-[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.2...HEAD
+[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.3...HEAD
+[4.3.3]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.2...v4.3.3
 [4.3.2]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.1...v4.3.2
 [4.3.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.0...v4.3.1
 [4.3.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.2.0...v4.3.0

--- a/README.md
+++ b/README.md
@@ -42,19 +42,14 @@ This extension has dependency on _[Live Server](https://marketplace.visualstudio
 - Output options are now only `expanded` and `compressed`
 - Only works on VS Code v1.50 and newer
 
-
-### 4.3.2 - 2021-01-15
+### 4.3.3 - 2021-01-18
 
 ### Fixed
-- Now handle errors caused by incorrect autoprefixer browser queries
-- Corrected output for unhandled errors that get output when running "Report an issue" from the command `liveSass.command.createIssue`
-
-### Updates
-- `sass` from `1.30.0` to `1.32.4`
-  - Various changes, see their [changelog](https://github.com/sass/dart-sass/blob/master/CHANGELOG.md)
-- `autoprefixer` from `10.1.0` to `10.2.1`
-  - Fixed transition-property warnings (by @Sheraff).
-- Other, non-facing changes. See changelog
+- Fixed [#15](https://github.com/glenn2223/vscode-live-sass-compiler/issues/15): No longer outputs absolute path in map file and map link in css output
+- Reinstated feature of partial files being checked for exclusion
+- Autoprefixer map lines now relate to actual SASS files rather than the css file generated
+- When there's an include list, a non partial file that's not "included" would still be processed
+- Now gets the correct list of included partial files
 
 *See the full changelog [here](CHANGELOG.md).*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "4.3.2",
+    "version": "4.3.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime with live browser reload.",
-    "version": "4.3.2",
+    "version": "4.3.3",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -243,7 +243,7 @@
         "webpack-cli": "^4.3.1"
     },
     "announcement": {
-        "onVersion": "4.3.2",
-        "message": "SassCompiler v4.3.2: Updates (including sass@1.32.4). Improved error handling (autoprefix & `Report an issue` command)"
+        "onVersion": "4.3.3",
+        "message": "SassCompiler v4.3.3: General bug squashing"
     }
 }

--- a/src/SassCompileHelper.ts
+++ b/src/SassCompileHelper.ts
@@ -25,6 +25,7 @@ export class SassHelper {
         Object.assign(data, options);
 
         data.file = SassPath;
+        data.omitSourceMapUrl = true;
         /*data.logger = {
             warning: (warning: compiler.SassFlag) => {
                 OutputWindow.Show("Warning:", warning.formatted.split("\n"), showOutputWindow);


### PR DESCRIPTION
## 4.3.3 - 2021-01-18

### Fixed
- Fixed [#15](https://github.com/glenn2223/vscode-live-sass-compiler/issues/15): No longer outputs absolute path in map file and map link in css output
- Reinstated feature of partial files being checked for exclusion
- Autoprefixer map lines now relate to actual SASS files rather than the css file generated
- When there's an include list, a non partial file that's not "included" would still be processed
- Now gets the correct list of included partial files