### PR TITLE
v4.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.3.4] - 2021-01-21
+
+### Fixed
+- Fixed [#18](https://github.com/glenn2223/vscode-live-sass-compiler/issues/18): On launch there is no output, nor any `Live SASS Compile` ouput selection, when the setting `watchOnLaunch` is `true`
+- Fixed: Autoprefixer warning saying `undefined` for file path when `generateMap` is `false`
+- Fixed: Autoprefixer `grid: "autoplace"` was forced
+  - If [this feature](https://github.com/postcss/autoprefixer#does-autoprefixer-polyfill-grid-layout-for-ie) is wanted then add `/* autoprefixer grid: autoplace */` to the start of your file
+
+### Updates
+- `sass` from `1.32.4` to `1.32.5`
+  - **Potentially breaking bug fix:** When using @for with numbers that have units, the iteration variable now matches the unit of the initial number. This matches the behavior of Ruby Sass and LibSass.
+  - Others: see [sass release notes](https://github.com/sass/dart-sass/releases/tag/1.32.5)
+
 ## [4.3.3] - 2021-01-18
 
 ### Fixed
@@ -159,7 +172,8 @@ All notable changes to this project will be documented in this file.
 
 
 
-[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.3...HEAD
+[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.4...HEAD
+[4.3.4]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.3...v4.3.4
 [4.3.3]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.2...v4.3.3
 [4.3.2]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.1...v4.3.2
 [4.3.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.0...v4.3.1

--- a/README.md
+++ b/README.md
@@ -42,14 +42,18 @@ This extension has dependency on _[Live Server](https://marketplace.visualstudio
 - Output options are now only `expanded` and `compressed`
 - Only works on VS Code v1.50 and newer
 
-### 4.3.3 - 2021-01-18
+### 4.3.4 - 2021-01-21
 
 ### Fixed
-- Fixed [#15](https://github.com/glenn2223/vscode-live-sass-compiler/issues/15): No longer outputs absolute path in map file and map link in css output
-- Reinstated feature of partial files being checked for exclusion
-- Autoprefixer map lines now relate to actual SASS files rather than the css file generated
-- When there's an include list, a non partial file that's not "included" would still be processed
-- Now gets the correct list of included partial files
+- Fixed [#18](https://github.com/glenn2223/vscode-live-sass-compiler/issues/18): On launch there is no output, nor any `Live SASS Compile` ouput selection, when the setting `watchOnLaunch` is `true`
+- Fixed: Autoprefixer warning saying `undefined` for file path when `generateMap` is `false`
+- Fixed: Autoprefixer `grid: "autoplace"` was forced
+  - If [this feature](https://github.com/postcss/autoprefixer#does-autoprefixer-polyfill-grid-layout-for-ie) is wanted then add `/* autoprefixer grid: autoplace */` to the start of your file
+
+### Updates
+- `sass` from `1.32.4` to `1.32.5`
+  - **Potentially breaking bug fix:** When using @for with numbers that have units, the iteration variable now matches the unit of the initial number. This matches the behavior of Ruby Sass and LibSass.
+  - Others: see [sass release notes](https://github.com/sass/dart-sass/releases/tag/1.32.5)
 
 *See the full changelog [here](CHANGELOG.md).*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "4.3.3",
+    "version": "4.3.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -808,9 +808,9 @@
             }
         },
         "chokidar": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.0.tgz",
-            "integrity": "sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+            "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -2397,9 +2397,9 @@
             "dev": true
         },
         "sass": {
-            "version": "1.32.4",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.4.tgz",
-            "integrity": "sha512-N0BT0PI/t3+gD8jKa83zJJUb7ssfQnRRfqN+GIErokW6U4guBpfYl8qYB+OFLEho+QvnV5ZH1R9qhUC/Z2Ch9w==",
+            "version": "1.32.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.5.tgz",
+            "integrity": "sha512-kU1yJ5zUAmPxr7f3q0YXTAd1oZjSR1g3tYyv+xu0HZSl5JiNOaE987eiz7wCUvbm4I9fGWGU2TgApTtcP4GMNQ==",
             "requires": {
                 "chokidar": ">=2.0.0 <4.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime with live browser reload.",
-    "version": "4.3.3",
+    "version": "4.3.4",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -243,7 +243,7 @@
         "webpack-cli": "^4.3.1"
     },
     "announcement": {
-        "onVersion": "4.3.3",
-        "message": "SassCompiler v4.3.3: General bug squashing"
+        "onVersion": "4.3.4",
+        "message": "SassCompiler v4.3.4: Updated to sass v1.32.5 & bug fixes"
     }
 }

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
         "autoprefixer": "^10.2.1",
         "glob": "^7.1.6",
         "postcss": "^8.2.4",
-        "sass": "^1.32.4"
+        "sass": "^1.32.5"
     },
     "devDependencies": {
         "@types/glob": "^7.1.3",

--- a/src/SassCompileHelper.ts
+++ b/src/SassCompileHelper.ts
@@ -36,8 +36,9 @@ export class SassHelper {
             },
         };*/
 
-        if (generateMap) data.sourceMap = mapFileUri;
-        else data.omitSourceMapUrl = true;
+        data.sourceMap = mapFileUri;
+
+        if (!generateMap) data.omitSourceMapUrl = true;
 
         try {
             return { result: compiler.renderSync(data), errorString: null };

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -465,22 +465,17 @@ export class AppModel {
                 // @ts-ignore
                 autoprefixer({
                     overrideBrowserslist: browsers,
-                    grid: "autoplace",
                 })
             );
 
-        const result = 
-            await prefixer.process(
-                css, 
-                {
-                    from: filePath,
-                    to: savePath,
-                    map: {
-                        inline: false,
-                        prev: map,
-                    },
-                }
-            );
+        const result = await prefixer.process(css, {
+            from: filePath,
+            to: savePath,
+            map: {
+                inline: false,
+                prev: map,
+            },
+        });
 
         result.warnings().forEach((warn) => {
             const body: string[] = [];

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -25,6 +25,13 @@ export class AppModel {
 
         this._logger = new ErrorLogger(workplaceState);
 
+        if (this.isWatching)
+            OutputWindow.Show(
+                "Watching...",
+                null,
+                Helper.getConfigSettings<boolean>("showOutputWindow")
+            );
+
         StatusBarUi.init(this.isWatching);
     }
 

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -10,7 +10,6 @@ import { Helper, IFormat } from "./helper";
 import { ErrorLogger, OutputWindow, WindowPopout } from "./VscodeExtensions";
 import { SassHelper } from "./SassCompileHelper";
 import { StatusBarUi } from "./StatusbarUi";
-import { ProcessOptions } from "postcss";
 
 import postcss from "postcss";
 

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -467,24 +467,25 @@ export class AppModel {
                     overrideBrowserslist: browsers,
                     grid: "autoplace",
                 })
-            ),
-            options: ProcessOptions = generateMap
-                ? {
-                      from: filePath,
-                      to: savePath,
-                      map: {
-                          inline: false,
-                          prev: map,
-                      },
-                  }
-                : {};
+            );
 
-        const result = await prefixer.process(css, options);
+        const result = 
+            await prefixer.process(
+                css, 
+                {
+                    from: filePath,
+                    to: savePath,
+                    map: {
+                        inline: false,
+                        prev: map,
+                    },
+                }
+            );
 
         result.warnings().forEach((warn) => {
             const body: string[] = [];
 
-            if (warn.node.source?.input.file !== null) {
+            if (warn.node.source?.input.file) {
                 body.push(warn.node.source.input.file + `:${warn.line}:${warn.column}`);
             }
 


### PR DESCRIPTION
## 4.3.4 - 2021-01-21

### Fixed
- Fixed [#18](https://github.com/glenn2223/vscode-live-sass-compiler/issues/18): On launch there is no output, nor any `Live SASS Compile` ouput selection, when the setting `watchOnLaunch` is `true`
- Fixed: Autoprefixer warning saying `undefined` for file path when `generateMap` is `false`
- Fixed: Autoprefixer `grid: "autoplace"` was forced
  - If [this feature](https://github.com/postcss/autoprefixer#does-autoprefixer-polyfill-grid-layout-for-ie) is wanted then add `/* autoprefixer grid: autoplace */` to the start of your file

### Updates
- `sass` from `1.32.4` to `1.32.5`
  - **Potentially breaking bug fix:** When using @for with numbers that have units, the iteration variable now matches the unit of the initial number. This matches the behavior of Ruby Sass and LibSass.
  - Others: see [sass release notes](https://github.com/sass/dart-sass/releases/tag/1.32.5)