### PR TITLE
v4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,26 @@ Types of changes
 - Fixed for any bug fixes.
 - Security in case of vulnerabilities.
 - Breaking changes for break in new revision
-- Other for notable changes that do not 
+- Other for noteable changes that do not 
  -->
 
 # Changelog
 All notable changes to this project will be documented in this file.
+
+## [4.4.1] - 2021-01-31
+
+### Fixed
+- Fixed: `forceBaseDirectory` has full support in multi-root workspaces
+- Fixed: the path in `forceBaseDirectory` is now checked to see if it exists. If not a user friendly message is displayed in the output
+- Fixed: an error when checking files would still compile what it could. This would hide the error message from the user
+- Incorrect patern matches in settings show user friendly messages rather than "does not match pattern"
 
 ## [4.4.0] - 2021-01-31
 
 ### Added
 - New setting: `liveSassCompile.settings.forceBaseDirectory` #25
   - A new setting that can help performance in large projects with few Sass/Scss files.
-  - **Note:** multi-root workspace with different folder structures can not use this efficiently (See [setting note](https://github.com/glenn2223/vscode-live-sass-compiler/blob/1d043a0541008dfa2b53c492f6a76dce4e3d9909/docs/settings.md) & [VS Code Feature Request](https://github.com/microsoft/vscode/issues/115482) (:+1: it) )
+  - ~~**Note:** multi-root workspace with different folder structures can not use this efficiently (See [setting note](https://github.com/glenn2223/vscode-live-sass-compiler/blob/1d043a0541008dfa2b53c492f6a76dce4e3d9909/docs/settings.md) & [VS Code Feature Request](https://github.com/microsoft/vscode/issues/115482) (:+1: it) )~~ Fixed in v4.4.1
 - New feature: The status bar `Error` and `Success` messages can be clicked which will open the Output Window #25
 
 ### Updates
@@ -194,7 +202,8 @@ All notable changes to this project will be documented in this file.
 
 
 
-[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.4...HEAD
+[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.1...HEAD
+[4.4.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.4...v4.4.0
 [4.3.4]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.3...v4.3.4
 [4.3.3]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.2...v4.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to this project will be documented in this file.
 - Various dev-dependancy updates
 
 ### Fixed
-- Part fix: Slwo file handling #22. Full fix in v5 as some small breaking changes
+- Part fix: Slow file handling #22. Full fix in v5 as some small breaking changes
   - The glob pattern matcher is causing bottlenecks, reducing load calls with small patch. However moving away from glob is the end-game (which will be happening in v5)
 - Fix: `compileCurrentSass` shows wrong message on fail
   - When you run `compileCurrentSass` and it would fail (for whatever reason) it would cause the output to show `Success` rather than `Error` (just the output was wrong, nothing else)

--- a/README.md
+++ b/README.md
@@ -42,26 +42,13 @@ This extension has dependency on _[Live Server](https://marketplace.visualstudio
 - Output options are now only `expanded` and `compressed`
 - Only works on VS Code v1.50 and newer
 
-### 4.4.0 - 2021-01-31
-
-### Added
-- New setting: `liveSassCompile.settings.forceBaseDirectory` #25
-  - A new setting that can help performance in large projects with few Sass/Scss files.
-  - **Note:** multi-root workspace with different folder structures can not use this efficiently (See [setting note](https://github.com/glenn2223/vscode-live-sass-compiler/blob/1d043a0541008dfa2b53c492f6a76dce4e3d9909/docs/settings.md) & [VS Code Feature Request](https://github.com/microsoft/vscode/issues/115482) (:+1: it) )
-- New feature: The status bar `Error` and `Success` messages can be clicked which will open the Output Window #25
-
-### Updates
-- `autoprefixer` from `10.2.1` to `10.2.4`
-  - Small bug fixes (nothing user facing)
-- Various dev-dependancy updates
+### 4.4.1 - 2021-01-31
 
 ### Fixed
-- Part fix: Slow file handling #22. Full fix in v5 as some small breaking changes
-  - The glob pattern matcher is causing bottlenecks, reducing load calls with small patch. However moving away from glob is the end-game (which will be happening in v5)
-- Fix: `compileCurrentSass` shows wrong message on fail
-  - When you run `compileCurrentSass` and it would fail (for whatever reason) it would cause the output to show `Success` rather than `Error` (just the output was wrong, nothing else)
-- Fix: Status bar inconsistancies during display changes
-  - When command bar is changing between visuals it was possible to cause the status and the shown message to be out of sync (due to clicks while setTimeouts are pending), the setup also meant you couldn't sync them again (unless you did a manual compile command)
+- Fixed: `forceBaseDirectory` has full support in multi-root workspaces
+- Fixed: the path in `forceBaseDirectory` is now checked to see if it exists. If not a user friendly message is displayed in the output
+- Fixed: an error when checking files would still compile what it could. This would hide the error message from the user
+- Incorrect patern matches in settings show user friendly messages rather than "does not match pattern"
 
 *See the full changelog [here](CHANGELOG.md).*
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -232,7 +232,12 @@ No Sass/Scss files outside of this folder will be watched/compiled when you save
 * _**Default:** `null`_
 * _**Note:** No leading slash but MUST have ending slash_
   * _Example: `src/style/`_
-* _**Note for multi-root workspaces:** This setting can be applied at workspace level however it can not vary from root to root. (opened [feature request](https://github.com/microsoft/vscode/issues/115482) on VS Code source)_
+* _**Note for multi-root workspaces:** This setting can be applied at workspace level. However, it can be overridden in each root using that root's specific setting file_  
+  * _Example: workspace setting is `src/Sass/` and root setting is `Assets/Style/`. In this case `Assets/Style/` would be used_
+
+>**:Warning: It is your responsibility to ensure the path exists and is correct.**  
+If it's not found it will output an error  
+If the path is wrong then nothing will be found and then compiled
 
 </details>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime with live browser reload.",
-    "version": "4.4.0",
+    "version": "4.4.1",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -257,7 +257,7 @@
         "webpack-cli": "^4.4.0"
     },
     "announcement": {
-        "onVersion": "4.4.0",
-        "message": "SassCompiler v4.4.0: New feature, updates & bug fixes"
+        "onVersion": "4.4.1",
+        "message": "SassCompiler v4.4.1: `forceBaseDirectory` now has better support in multi-root workspaces"
     }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
             }
         ],
         "configuration": {
-            "title": "Live Sass Compile Config",
+            "title": "Live Sass Compiler",
             "properties": {
                 "liveSassCompile.settings.formats": {
                     "type": "array",
@@ -118,6 +118,7 @@
                                     "null"
                                 ],
                                 "pattern": "^[\\~|/|\\\\]",
+                                "patternErrorMessage": "Must start with any of:\n`/` or `\\` (for workspace root)\n`~/` or `~\\` for relative to the file being processed",
                                 "default": null
                             },
                             "savePathSegmentKeys": {
@@ -135,6 +136,7 @@
                                     "null"
                                 ],
                                 "pattern": "[^\\/]",
+                                "patternErrorMessage": "Must not contain any path seperators (`/` or `\\`)",
                                 "default": null
                             }
                         },
@@ -202,9 +204,11 @@
                         "string",
                         "null"
                     ],
+                    "scope": "resource",
                     "default": null,
                     "pattern": "^[^\\/].+[\\/]$",
-                    "description": "Defines a subdirectory to search from (no directory outside of this will be search).\nNote: Must not start with a slash but must end with one"
+                    "patternErrorMessage": "Can't start with a path seperator (`/` or `\\`) and must end with one",
+                    "description": "Defines a subdirectory to search from (no directory outside of this will be search)"
                 }
             }
         }

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -535,8 +535,7 @@ export class AppModel {
 
     private async isSassFileExcluded(sassPath: string): Promise<boolean> {
         const excludeItems = Helper.getConfigSettings<string[]>("excludeList"),
-            includeItems = Helper.getConfigSettings<string[] | null>("includeItems"),
-            forceBaseDirectory = Helper.getConfigSettings<string | null>("forceBaseDirectory");
+            includeItems = Helper.getConfigSettings<string[] | null>("includeItems");
         let fileList = ["**/*.s[a|c]ss"];
 
         if (includeItems && includeItems.length) {
@@ -546,6 +545,10 @@ export class AppModel {
         const fileFound = (
             await Promise.all(
                 vscode.workspace.workspaceFolders.map(async (folder) => {
+                    const forceBaseDirectory = Helper.getConfigSettings<string | null>(
+                        "forceBaseDirectory",
+                        folder
+                    );
                     let basePath = folder.uri.fsPath;
 
                     if (forceBaseDirectory) basePath = path.resolve(basePath, forceBaseDirectory);

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -9,11 +9,11 @@ export interface IFormat {
 }
 
 export class Helper {
-    private static get configSettings() {
-        return vscode.workspace.getConfiguration("liveSassCompile.settings");
+    private static configSettings(folder?: vscode.WorkspaceFolder) {
+        return vscode.workspace.getConfiguration("liveSassCompile.settings", folder);
     }
 
-    static getConfigSettings<T>(val: string): T {
-        return this.configSettings.get(val) as T;
+    static getConfigSettings<T>(val: string, folder?: vscode.WorkspaceFolder): T {
+        return this.configSettings(folder).get(val) as T;
     }
 }


### PR DESCRIPTION
## 4.4.1 - 2021-01-31

### Fixed
- Fixed: `forceBaseDirectory` has full support in multi-root workspaces
- Fixed: the path in `forceBaseDirectory` is now checked to see if it exists. If not a user friendly message is displayed in the output
- Fixed: an error when checking files would still compile what it could. This would hide the error message from the user
- Incorrect patern matches in settings show user friendly messages rather than "does not match pattern"