### PR TITLE
v5.0.0-rc2 => ahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.0.0-rc.2] - 2021-04-02
+
+### Fixes
+- Relative paths in the exclude & include settings aren't working ([#49](https://github.com/glenn2223/vscode-live-sass-compiler/issues/49))
+
+## Changed
+- Exclude setting did not have a pattern matching string ([#30](https://github.com/glenn2223/vscode-live-sass-compiler/issues/30))<!-- Remove this on full v5 release -->
+
 ## [5.0.0-rc.1] - 2021-04-01
 
 ### Breaking changes
@@ -264,6 +272,7 @@ All notable changes to this project will be documented in this file.
 
 
 [Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.0-rc.1...HEAD
+[5.0.0-rc.2]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.0-rc.1...v5.0.0-rc.2
 [5.0.0-rc.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.1...v5.0.0-rc.1
 [4.4.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.4...v4.4.0

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -96,7 +96,7 @@ Use an array of various glob patterns to exclude files or entire folders. All ma
 **Type:** `string[]?`  
 **Default**
 ```json
-[ "**/node_modules/**", ".vscode/**" ]
+[ "/**/node_modules/**", "/.vscode/**" ]
 ```
 
 <details>
@@ -107,7 +107,7 @@ To exclude all files except `file1.scss` & `file2.scss` from the directory `path
 
 ```json
 "liveSassCompile.settings.excludeList": [
-    "path/subpath/*[!(file1|file2)].scss"
+    "/path/subpath/*[!(file1|file2)].scss"
 ]
 ```
 
@@ -116,7 +116,7 @@ Match regex expressions
 
 ```json
 "liveSassCompile.settings.excludeList": [
-    "path\/subpath\/[A-Za-z0-9_]+.scss"
+    "/path/subpath/[A-Za-z0-9_]+.scss"
 ]
 ```
 
@@ -125,7 +125,7 @@ Match alphas, alpha numerics, words and [more][Full POSIX List]
 
 ```json
 "liveSassCompile.settings.excludeList": [
-    "path/subpath/[:word:]+.scss"
+    "/path/subpath/[:word:]+.scss"
 ]
 ```
 
@@ -146,8 +146,8 @@ Process only these specified files. Useful for when you deal with only a few sas
 
 ```json
 "liveSassCompile.settings.includeItems": [
-    "path/subpath/a.scss",
-    "path/subpath/b.scss",
+    "/path/subpath/a.scss",
+    "/path/subpath/b.scss",
 ]
 ``` 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "5.0.0-rc.1",
+    "version": "5.0.0-rc.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime with live browser reload.",
-    "version": "5.0.0-rc.1",
+    "version": "5.0.0-rc.2",
     "preview": true,
     "publisher": "glenn2223",
     "author": {
@@ -155,12 +155,14 @@
                 "liveSassCompile.settings.excludeList": {
                     "type": "array",
                     "default": [
-                        "**/node_modules/**",
-                        ".vscode/**"
+                        "/**/node_modules/**",
+                        "/.vscode/**"
                     ],
                     "description": "All Sass/Scss files inside the folders will be excluded. \n\nExamples: \n'**/node_modules/**',\n'.vscode/**', \n'.history/**' \n\nGlob Patterns are accepted.",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[\\/].+",
+                        "patternErrorMessage": "Must start with a path separator (`/` or `\\`)"
                     }
                 },
                 "liveSassCompile.settings.includeItems": {
@@ -274,7 +276,7 @@
         "webpack-cli": "^4.6.0"
     },
     "announcement": {
-        "onVersion": "5.0.0-rc.1",
-        "message": "SassCompiler v5(rc 5): New in this release: Loads! See the changelog for more info. --- Thanks for testing! Please be aware that breaking changes can happen between each release candidate."
+        "onVersion": "5.0.0-rc.2",
+        "message": "SassCompiler v5(rc 2): New in this release: Fixes. See the changelog for more info. --- Thanks for testing! Please be aware that breaking changes can happen between each release candidate."
     }
 }


### PR DESCRIPTION
# 5.0.0-rc.2 - 2021-04-02

### Fixes
- Relative paths in the exclude & include settings aren't working ([#49](https://github.com/glenn2223/vscode-live-sass-compiler/issues/49))

## Changed
- Exclude setting did not have a pattern matching string ([#30](https://github.com/glenn2223/vscode-live-sass-compiler/issues/30))<!-- Remove this on full v5 release -->