### PR TITLE
v5.0.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,9 +43,20 @@ jobs:
 #      if: runner.os != 'Linux'
 #      name: Test extension
 
+    - id: get-name
+      if: success() && startsWith( github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
+      uses: actions/github-script@0.9.0
+      with:
+        script: |
+          const ver = github.event.release.tag_name.substr(1)
+          core.setOutput('name', `live-sass-${ver}.vsix`)
+
+    - name: Package
+      run: vsce package --yarn
+
     - name: Publish - vsce
-      if: success() && startsWith( github.ref, 'refs/tags/releases/') && matrix.os == 'ubuntu-latest'
-      run: vsce publish --yarn
+      if: success() && startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
+      run: vsce publish ${{ steps.get-name.outputs.name }} --yarn
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
         
@@ -53,7 +64,15 @@ jobs:
       run: npm i ovsx -g
       
     - name: Publish - ovsx
-      if: success() && startsWith( github.ref, 'refs/tags/releases/') && matrix.os == 'ubuntu-latest'
-      run: ovsx publish
+      if: success() && startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
+      run: ovsx publish ${{ steps.get-name.outputs.name }}
       env:
         OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        
+    - name: Upload asset
+      if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
+      uses: softprops/action-gh-release@v0.1.5
+      with:
+        files: ${{ steps.get-name.outputs.name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,8 +283,8 @@ All notable changes to this project will be documented in this file.
 
 
 [Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.2...HEAD
-[5.0.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.1...v5.0.2
-[5.0.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.0...v5.0.1
+[5.0.2]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.1...v5.0.2
+[5.0.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.1...v5.0.0
 [4.4.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.3.4...v4.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.0.2] - 2021-04-19
+
+### Updated
+- `picomatch` from `10.2.4` to `10.2.5`
+  - Do not skip pattern separator for square brackets
+  - Other small changes *(nothing user facing)*
+- `postcss` from `8.2.9` to `8.2.10`
+  - Fixed ReDoS vulnerabilities in source map parsing
+  - Other small changes *(nothing user facing)*
+- `sass` from `1.32.8` to `1.32.11`
+  - Small changes *(nothing user facing)*
+- Various dev dependency updates *(nothing user facing)*
+
 ## [5.0.1] - 2021-04-07
 
 ### Fixed
@@ -269,7 +282,8 @@ All notable changes to this project will be documented in this file.
 | 0.0.1 | 11.07.17 | Initial Preview Release with following key features. <br> – Live SASS & SCSS Compile. <br> – Customizable file location of exported CSS. <br> – Customizable exported CSS Style (`expanded`, `compact`, `compressed`, `nested`.)<br> – Quick Status bar control.<br> – Live Reload to browser (`Live Server` extension dependency). |
 
 
-[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.1...HEAD
+[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.2...HEAD
+[5.0.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.1...v5.0.2
 [5.0.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.1...v5.0.0
 [4.4.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.0...v4.4.1

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -53,7 +53,7 @@ The final save path is dependant on these three settings. However, `savePath` ta
     // More Complex
     // (See issue 26: https://github.com/ritwickdey/vscode-live-sass-compiler/issues/26)
     {
-        "format": "nested",
+        "format": "compressed",
         "extensionName": ".min.css",
 
         // ~ -> denotes relative to each sass file
@@ -61,7 +61,7 @@ The final save path is dependant on these three settings. However, `savePath` ta
     },
     // Segment replacement example
     {
-        "format": "compact",
+        "format": "compressed",
         "extensionName": ".min.css",
 
         // "/Assets/SCSS/main.scss" -> translates to "/Assets/Style/main.css"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -125,9 +125,9 @@
             "dev": true
         },
         "@types/eslint": {
-            "version": "7.2.8",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
-            "integrity": "sha512-RTKvBsfz0T8CKOGZMfuluDNyMFHnu5lvNr4hWEsQeHXH6FcmIDIozOyWMh36nLGMwVd5UFNXC2xztA8lln22MQ==",
+            "version": "7.2.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
+            "integrity": "sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -145,9 +145,9 @@
             }
         },
         "@types/estree": {
-            "version": "0.0.46",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-            "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
+            "version": "0.0.47",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+            "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
             "dev": true
         },
         "@types/glob": {
@@ -179,15 +179,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.37",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-            "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+            "version": "14.14.41",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+            "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
             "dev": true
         },
         "@types/picomatch": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.2.1.tgz",
-            "integrity": "sha512-26/tQcDmJXYHiaWAAIjnTVL5nwrT+IVaqFZIbBImAuKk/r/j1r/1hmZ7uaOzG6IknqP3QHcNNQ6QO8Vp28lUoA==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.2.2.tgz",
+            "integrity": "sha512-XygLVvHxaFK0w9sDf7Mk1wrugM0ig44Y5Fb2NmQcvznPkEfENprS6GhXVoO3AGicbhkRrmu9J7Lu7FFKqkCS8g==",
             "dev": true
         },
         "@types/sass": {
@@ -206,71 +206,142 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.20.0.tgz",
-            "integrity": "sha512-sw+3HO5aehYqn5w177z2D82ZQlqHCwcKSMboueo7oE4KU9QiC0SAgfS/D4z9xXvpTc8Bt41Raa9fBR8T2tIhoQ==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
+            "integrity": "sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.20.0",
-                "@typescript-eslint/scope-manager": "4.20.0",
+                "@typescript-eslint/experimental-utils": "4.22.0",
+                "@typescript-eslint/scope-manager": "4.22.0",
                 "debug": "^4.1.1",
                 "functional-red-black-tree": "^1.0.1",
                 "lodash": "^4.17.15",
                 "regexpp": "^3.0.0",
                 "semver": "^7.3.2",
                 "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "4.22.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
+                    "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.22.0",
+                        "@typescript-eslint/visitor-keys": "4.22.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "4.22.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
+                    "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
+                    "dev": true
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "4.22.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
+                    "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.22.0",
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.20.0.tgz",
-            "integrity": "sha512-sQNlf6rjLq2yB5lELl3gOE7OuoA/6IVXJUJ+Vs7emrQMva14CkOwyQwD7CW+TkmOJ4Q/YGmoDLmbfFrpGmbKng==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz",
+            "integrity": "sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.20.0",
-                "@typescript-eslint/types": "4.20.0",
-                "@typescript-eslint/typescript-estree": "4.20.0",
+                "@typescript-eslint/scope-manager": "4.22.0",
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/typescript-estree": "4.22.0",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
+            },
+            "dependencies": {
+                "@typescript-eslint/scope-manager": {
+                    "version": "4.22.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
+                    "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.22.0",
+                        "@typescript-eslint/visitor-keys": "4.22.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "4.22.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
+                    "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "4.22.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
+                    "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.22.0",
+                        "@typescript-eslint/visitor-keys": "4.22.0",
+                        "debug": "^4.1.1",
+                        "globby": "^11.0.1",
+                        "is-glob": "^4.0.1",
+                        "semver": "^7.3.2",
+                        "tsutils": "^3.17.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "4.22.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
+                    "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.22.0",
+                        "eslint-visitor-keys": "^2.0.0"
+                    }
+                }
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.20.0.tgz",
-            "integrity": "sha512-m6vDtgL9EABdjMtKVw5rr6DdeMCH3OA1vFb0dAyuZSa3e5yw1YRzlwFnm9knma9Lz6b2GPvoNSa8vOXrqsaglA==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.0.tgz",
+            "integrity": "sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.20.0",
-                "@typescript-eslint/types": "4.20.0",
-                "@typescript-eslint/typescript-estree": "4.20.0",
+                "@typescript-eslint/scope-manager": "4.22.0",
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/typescript-estree": "4.22.0",
                 "debug": "^4.1.1"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.20.0.tgz",
-            "integrity": "sha512-/zm6WR6iclD5HhGpcwl/GOYDTzrTHmvf8LLLkwKqqPKG6+KZt/CfSgPCiybshmck66M2L5fWSF/MKNuCwtKQSQ==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
+            "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.20.0",
-                "@typescript-eslint/visitor-keys": "4.20.0"
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/visitor-keys": "4.22.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.20.0.tgz",
-            "integrity": "sha512-cYY+1PIjei1nk49JAPnH1VEnu7OYdWRdJhYI5wiKOUMhLTG1qsx5cQxCUTuwWCmQoyriadz3Ni8HZmGSofeC+w==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
+            "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.20.0.tgz",
-            "integrity": "sha512-Knpp0reOd4ZsyoEJdW8i/sK3mtZ47Ls7ZHvD8WVABNx5Xnn7KhenMTRGegoyMTx6TiXlOVgMz9r0pDgXTEEIHA==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
+            "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.20.0",
-                "@typescript-eslint/visitor-keys": "4.20.0",
+                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/visitor-keys": "4.22.0",
                 "debug": "^4.1.1",
                 "globby": "^11.0.1",
                 "is-glob": "^4.0.1",
@@ -279,12 +350,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.20.0.tgz",
-            "integrity": "sha512-NXKRM3oOVQL8yNFDNCZuieRIwZ5UtjNLYtmMx2PacEAGmbaEYtGgVHUHVyZvU/0rYZcizdrWjDo+WBtRPSgq+A==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
+            "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.20.0",
+                "@typescript-eslint/types": "4.22.0",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -674,16 +745,16 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.16.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-            "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+            "version": "4.16.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+            "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001181",
-                "colorette": "^1.2.1",
-                "electron-to-chromium": "^1.3.649",
+                "caniuse-lite": "^1.0.30001208",
+                "colorette": "^1.2.2",
+                "electron-to-chromium": "^1.3.712",
                 "escalade": "^3.1.1",
-                "node-releases": "^1.1.70"
+                "node-releases": "^1.1.71"
             }
         },
         "buffer-from": {
@@ -727,9 +798,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001205",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
-            "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==",
+            "version": "1.0.30001211",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001211.tgz",
+            "integrity": "sha512-v3GXWKofIkN3PkSidLI5d1oqeKNsam9nQkqieoMhP87nxOY0RPDC8X2+jcv8pjV4dRozPLSoMqNii9sDViOlIg==",
             "dev": true
         },
         "chainsaw": {
@@ -801,13 +872,10 @@
             }
         },
         "chrome-trace-event": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-            "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.9.0"
-            }
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "dev": true
         },
         "cliui": {
             "version": "7.0.4",
@@ -849,8 +917,7 @@
         "colorette": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-            "dev": true
+            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
         },
         "commander": {
             "version": "2.20.3",
@@ -936,9 +1003,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.705",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.705.tgz",
-            "integrity": "sha512-agtrL5vLSOIK89sE/YSzAgqCw76eZ60gf3J7Tid5RfLbSp5H4nWL28/dIV+H+ZhNNi1JNiaF62jffwYsAyXc0g==",
+            "version": "1.3.717",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
+            "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
             "dev": true
         },
         "emoji-regex": {
@@ -954,14 +1021,13 @@
             "dev": true
         },
         "enhanced-resolve": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
-            "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.0.tgz",
+            "integrity": "sha512-Sl3KRpJA8OpprrtaIswVki3cWPiPKxXuFxJXBp+zNb6s6VwNWwFRUdtmzd2ReUut8n+sCPx7QCtQ7w5wfJhSgQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.5.0",
-                "tapable": "^1.0.0"
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
             }
         },
         "enquirer": {
@@ -978,15 +1044,6 @@
             "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.4.tgz",
             "integrity": "sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==",
             "dev": true
-        },
-        "errno": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
-            "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-            "dev": true,
-            "requires": {
-                "prr": "~1.0.1"
-            }
         },
         "es-module-lexer": {
             "version": "0.4.1",
@@ -1006,9 +1063,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.23.0.tgz",
-            "integrity": "sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==",
+            "version": "7.24.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
+            "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
@@ -1384,9 +1441,9 @@
             "dev": true
         },
         "globals": {
-            "version": "13.7.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
-            "integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
+            "version": "13.8.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+            "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -1779,16 +1836,6 @@
                 "yallist": "^4.0.0"
             }
         },
-        "memory-fs": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-            "dev": true,
-            "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
-            }
-        },
         "merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -1812,18 +1859,18 @@
             }
         },
         "mime-db": {
-            "version": "1.46.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-            "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+            "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.29",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-            "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+            "version": "2.1.30",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+            "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
             "dev": true,
             "requires": {
-                "mime-db": "1.46.0"
+                "mime-db": "1.47.0"
             }
         },
         "mimic-fn": {
@@ -2083,9 +2130,9 @@
             "dev": true
         },
         "picomatch": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
         },
         "pkg-dir": {
             "version": "4.2.0",
@@ -2136,20 +2183,13 @@
             }
         },
         "postcss": {
-            "version": "8.2.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+            "version": "8.2.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
+            "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
             "requires": {
                 "colorette": "^1.2.2",
                 "nanoid": "^3.1.22",
                 "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "colorette": {
-                    "version": "1.2.2",
-                    "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-                    "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
-                }
             }
         },
         "postcss-value-parser": {
@@ -2173,12 +2213,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "dev": true
-        },
-        "prr": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
             "dev": true
         },
         "punycode": {
@@ -2324,11 +2358,11 @@
             "dev": true
         },
         "sass": {
-            "version": "1.32.8",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
-            "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
+            "version": "1.32.11",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.11.tgz",
+            "integrity": "sha512-O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==",
             "requires": {
-                "chokidar": ">=2.0.0 <4.0.0"
+                "chokidar": ">=3.0.0 <4.0.0"
             }
         },
         "schema-utils": {
@@ -2533,9 +2567,9 @@
             }
         },
         "table": {
-            "version": "6.0.9",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.0.9.tgz",
-            "integrity": "sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.3.0.tgz",
+            "integrity": "sha512-gM9kB7aNIuSagW89Fh+SdL49uhKnVSORxMcV72u/dfptFdqExInNn5M21wgq/Uf5UdJpsboFhNe/0SoNKjaxzg==",
             "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
@@ -2550,9 +2584,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.0.3",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.3.tgz",
-                    "integrity": "sha512-Df6NAivu9KpZw+q8ySijAgLvr1mUA5ihkRvCLCxpdYR21ann5yIuN+PpFxmweSj7i3yjJ0x5LN5KVs0RRzskAQ==",
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+                    "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -2570,9 +2604,9 @@
             }
         },
         "tapable": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+            "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
             "dev": true
         },
         "terser": {
@@ -2640,13 +2674,13 @@
             "dev": true
         },
         "ts-loader": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.1.0.tgz",
-            "integrity": "sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.0.0.tgz",
+            "integrity": "sha512-okLMCTkzp1lCldwJ+/+mEY66qilDpwAs5Xs8REG9IwjfbG9fRQmt4a6XCFeFU6XaVI2C0qOEEEu+jIcWAUgc4w==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
-                "enhanced-resolve": "^4.0.0",
+                "enhanced-resolve": "^5.0.0",
                 "loader-utils": "^2.0.0",
                 "micromatch": "^4.0.0",
                 "semver": "^7.3.4"
@@ -2683,9 +2717,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-            "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+            "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
             "dev": true
         },
         "unzipper": {
@@ -2750,20 +2784,20 @@
             }
         },
         "webpack": {
-            "version": "5.30.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
-            "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
+            "version": "5.34.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.34.0.tgz",
+            "integrity": "sha512-+WiFMgaZqhu7zKN64LQ7z0Ml4WWI+9RwG6zmS0wJDQXiCeg3hpN8fYFNJ+6WlosDT55yVxTfK7XHUAOVR4rLyA==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.46",
+                "@types/estree": "^0.0.47",
                 "@webassemblyjs/ast": "1.11.0",
                 "@webassemblyjs/wasm-edit": "1.11.0",
                 "@webassemblyjs/wasm-parser": "1.11.0",
                 "acorn": "^8.0.4",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.7.0",
+                "enhanced-resolve": "^5.8.0",
                 "es-module-lexer": "^0.4.0",
                 "eslint-scope": "^5.1.1",
                 "events": "^3.2.0",
@@ -2781,25 +2815,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-                    "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
-                    "dev": true
-                },
-                "enhanced-resolve": {
-                    "version": "5.7.0",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
-                    "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.4",
-                        "tapable": "^2.2.0"
-                    }
-                },
-                "tapable": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-                    "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+                    "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime with live browser reload.",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -253,30 +253,30 @@
     "dependencies": {
         "autoprefixer": "^10.2.5",
         "fdir": "^5.0.0",
-        "picomatch": "^2.2.2",
-        "postcss": "^8.2.9",
-        "sass": "^1.32.8"
+        "picomatch": "^2.2.3",
+        "postcss": "^8.2.10",
+        "sass": "^1.32.11"
     },
     "devDependencies": {
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
-        "@types/node": "^14.14.37",
-        "@types/picomatch": "^2.2.1",
+        "@types/node": "^14.14.41",
+        "@types/picomatch": "^2.2.2",
         "@types/sass": "^1.16.0",
         "@types/vscode": "^1.50.0",
-        "@typescript-eslint/eslint-plugin": "^4.20.0",
-        "@typescript-eslint/parser": "^4.20.0",
-        "eslint": "^7.23.0",
+        "@typescript-eslint/eslint-plugin": "^4.22.0",
+        "@typescript-eslint/parser": "^4.22.0",
+        "eslint": "^7.24.0",
         "mocha": "^8.3.2",
         "terser-webpack-plugin": "^5.1.1",
-        "ts-loader": "^8.1.0",
-        "typescript": "^4.2.3",
+        "ts-loader": "^9.0.0",
+        "typescript": "^4.2.4",
         "vscode-test": "^1.5.2",
-        "webpack": "^5.30.0",
+        "webpack": "^5.34.0",
         "webpack-cli": "^4.6.0"
     },
     "announcement": {
-        "onVersion": "5.0.1",
-        "message": "SassCompiler v5: There have been lots of changes in v5! Please see the changelog for all the details, including those about the breaking changes."
+        "onVersion": "5.0.2",
+        "message": "SassCompiler v5.0.2: Just some dependancy bumps. Please note: there have been lots of changes in v5! Please see the changelog for all the details, including those about the breaking changes."
     }
 }


### PR DESCRIPTION
# 5.0.2 - 2021-04-19

### Updated
- `picomatch` from `10.2.4` to `10.2.5`
  - Do not skip pattern separator for square brackets
  - Other small changes *(nothing user facing)*
- `postcss` from `8.2.9` to `8.2.10`
  - Fixed ReDoS vulnerabilities in source map parsing
  - Other small changes *(nothing user facing)*
- `sass` from `1.32.8` to `1.32.11`
  - Small changes *(nothing user facing)*
- Various dev dependency updates *(nothing user facing)*