### PR TITLE
v5.0.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,24 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - id: test
+      uses: actions/github-script@0.9.0
+      with:
+        script: |
+          console.log('test', github)
+
+    - id: test2
+      uses: actions/github-script@0.9.0
+      with:
+        script: |
+          console.log('test 2', ${{ github }})
+
+    - id: break
+      uses: actions/github-script@0.9.0
+      with:
+        script: |
+          consssssssole.log(conssssss)
       
     - name: Install Node.js
       uses: actions/setup-node@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,23 +23,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - id: test
+    - id: Info
       uses: actions/github-script@0.9.0
       with:
         script: |
-          console.log('test', github)
-
-    - id: test2
-      uses: actions/github-script@0.9.0
-      with:
-        script: |
-          console.log('test 2', ${{ github }})
-
-    - id: break
-      uses: actions/github-script@0.9.0
-      with:
-        script: |
-          consssssssole.log(conssssss)
+          console.log('Github Info', { ref: github.ref, event: github.event, release: github.event.release })
       
     - name: Install Node.js
       uses: actions/setup-node@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,11 @@ All notable changes to this project will be documented in this file.
 
 ## [5.0.3] - 2021-05-05
 
-## Fixed
-- Removed reference to live reload in `package.json`
-
 ### Changed
 - The default for `liveSassCompile.settings.showOutputWindowOn` is now `Information`
   - To prevent future issues like [#70](https://github.com/glenn2223/vscode-live-sass-compiler/issues/70) & [#76](https://github.com/glenn2223/vscode-live-sass-compiler/issues/76). *An issue because saving didn't output the same details as the original extension*
 - Updated the documentation to match this - and also sorted a couple of typos
+- Removed reference to live reload in `package.json`
 
 ### Updated
 - `postcss` from `8.2.10` to `8.2.14`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - The default for `liveSassCompile.settings.showOutputWindowOn` is now `Information`
-  - To prevent future issues like [#70](https://github.com/glenn2223/vscode-live-sass-compiler/issues/70) & [#76](https://github.com/glenn2223/vscode-live-sass-compiler/issues/76). *An issue because saving didn't output the same details as the original extension*
+  - To prevent future issues like [#70](https://github.com/glenn2223/vscode-live-sass-compiler/issues/70) & [#76](https://github.com/glenn2223/vscode-live-sass-compiler/issues/76). *Where issues are created because, by default, compiling didn't output the same details that the original extension did*
 - Updated the documentation to match this - and also sorted a couple of typos
 - Removed reference to live reload in `package.json`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - The default for `liveSassCompile.settings.showOutputWindowOn` is now `Information`
   - To prevent future issues like [#70](https://github.com/glenn2223/vscode-live-sass-compiler/issues/70) & [#76](https://github.com/glenn2223/vscode-live-sass-compiler/issues/76). *Where issues are created because, by default, compiling didn't output the same details that the original extension did*
-- Updated the documentation to match this - and also sorted a couple of typos
+- Updated the documentation to match the above change - and also sorted a couple of typos
 - Removed reference to live reload in `package.json`
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,24 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.0.3] - 2021-05-05
+
+## Fixed
+- Removed reference to live reload in `package.json`
+
+### Changed
+- The default for `liveSassCompile.settings.showOutputWindowOn` is now `Information`
+  - To prevent future issues like [#70](https://github.com/glenn2223/vscode-live-sass-compiler/issues/70) & [#76](https://github.com/glenn2223/vscode-live-sass-compiler/issues/76). *An issue because saving didn't output the same details as the original extension*
+- Updated the documentation to match this - and also sorted a couple of typos
+
+### Updated
+- `postcss` from `8.2.10` to `8.2.14`
+  - Fixed ReDoS vulnerabilities in source map parsing
+  - Other small changes *(nothing user facing)*
+- `sass` from `1.32.11` to `1.32.12`
+  - Fix a bug that disallowed more than one module from extending the same selector from a module if that selector itself extended a selector from another upstream module.
+- Various dev dependency updates *(nothing user facing)*
+
 ## [5.0.2] - 2021-04-19
 
 ### Updated
@@ -282,7 +300,8 @@ All notable changes to this project will be documented in this file.
 | 0.0.1 | 11.07.17 | Initial Preview Release with following key features. <br> – Live SASS & SCSS Compile. <br> – Customizable file location of exported CSS. <br> – Customizable exported CSS Style (`expanded`, `compact`, `compressed`, `nested`.)<br> – Quick Status bar control.<br> – Live Reload to browser (`Live Server` extension dependency). |
 
 
-[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.2...HEAD
+[Unreleased]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.3...HEAD
+[5.0.2]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.2...v5.0.3
 [5.0.2]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v4.4.1...v5.0.0

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -93,9 +93,9 @@ Here's some of the most important changes:
     - The default is `defaults`
     - `null` is no longer accepted, use `false` instead
     - When `true` we will find a `.browserslistrc` file or `browserslist` in your `package.json`. No more duplicating settings!
-  - `showOutputWindow` is now `showOutputWindowOn` and uses log values (`Debug`, `Error`, etc.). It's default log level is `Warning`
+  - `showOutputWindow` is now `showOutputWindowOn` and uses log values (`Debug`, `Error`, etc.). It's default log level is `Information` - at this level it will output the same information that the original extension does
 - Some settings are new!
-  - `savePathSegmentKeys` and `savePathReplaceSegmentsWith`: when used in combination you can choose a to replace folder segments in the save path
+  - `savePathSegmentKeys` and `savePathReplaceSegmentsWith`: when used in combination you can choose to replace folder segments in the save path
   - `watchOnLaunch`: state whether you want to watch files upon launch
   - `compileOnWatch`: state if files should be compiled upon watching
   - `forceBaseDirectory`: state the base directory of all you SASS files. Aids in reducing wasted resources while searching for files
@@ -105,7 +105,7 @@ Here are some things you probably won't care about as much
 - We abandoned `glob` (the package, not the patterns) and we now use `fdir` which is blazingly fast
 - New commands!
   - `liveSass.command.compileCurrentSass`: perform a one-time compilation of the current SASS file
-  - `liveSass.command.createIssue`: create an issue in GutHub. If an unexpected error occurred then this information is readily available to paste into the new issue
+  - `liveSass.command.createIssue`: opens a link to create a new issue in GutHub. If an unexpected error occurred then error information is readily available to paste into the new issue
   - `liveSass.command.debugInclusion`: check if the current SASS file will be included, based on your settings
   - `liveSass.command.debugFileList`: get a full list of files that are included and excluded
 - We support multi-root/multi-folder workspaces

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -185,7 +185,7 @@ Autoprefix unsupported CSS properties (e.g. `transform` will also add `-ms-trans
 Set the logging level at which errors will be shown in the output window. *There is also a [command](#livesasscommandopenoutputwindow)*.
 
 **Type:** `Trace`, `Debug`, `Information`, `Warning`, `Error` or `None`  
-**Default:** `Warning`
+**Default:** `Information`
 
 <details>
 <summary> Choosing the right output level </summary>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "5.0.2",
+    "version": "5.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -14,18 +14,18 @@
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.12.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-            "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+            "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-            "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+            "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.12.11",
+                "@babel/helper-validator-identifier": "^7.14.0",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -179,9 +179,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.41",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-            "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+            "version": "15.0.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
+            "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
             "dev": true
         },
         "@types/picomatch": {
@@ -206,13 +206,13 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
-            "integrity": "sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.1.tgz",
+            "integrity": "sha512-kVTAghWDDhsvQ602tHBc6WmQkdaYbkcTwZu+7l24jtJiYvm9l+/y/b2BZANEezxPDiX5MK2ZecE+9BFi/YJryw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.22.0",
-                "@typescript-eslint/scope-manager": "4.22.0",
+                "@typescript-eslint/experimental-utils": "4.22.1",
+                "@typescript-eslint/scope-manager": "4.22.1",
                 "debug": "^4.1.1",
                 "functional-red-black-tree": "^1.0.1",
                 "lodash": "^4.17.15",
@@ -222,71 +222,71 @@
             },
             "dependencies": {
                 "@typescript-eslint/scope-manager": {
-                    "version": "4.22.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
-                    "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
+                    "version": "4.22.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.1.tgz",
+                    "integrity": "sha512-d5bAiPBiessSmNi8Amq/RuLslvcumxLmyhf1/Xa9IuaoFJ0YtshlJKxhlbY7l2JdEk3wS0EnmnfeJWSvADOe0g==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "4.22.0",
-                        "@typescript-eslint/visitor-keys": "4.22.0"
+                        "@typescript-eslint/types": "4.22.1",
+                        "@typescript-eslint/visitor-keys": "4.22.1"
                     }
                 },
                 "@typescript-eslint/types": {
-                    "version": "4.22.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
-                    "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
+                    "version": "4.22.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.1.tgz",
+                    "integrity": "sha512-2HTkbkdAeI3OOcWbqA8hWf/7z9c6gkmnWNGz0dKSLYLWywUlkOAQ2XcjhlKLj5xBFDf8FgAOF5aQbnLRvgNbCw==",
                     "dev": true
                 },
                 "@typescript-eslint/visitor-keys": {
-                    "version": "4.22.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
-                    "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
+                    "version": "4.22.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.1.tgz",
+                    "integrity": "sha512-WPkOrIRm+WCLZxXQHCi+WG8T2MMTUFR70rWjdWYddLT7cEfb2P4a3O/J2U1FBVsSFTocXLCoXWY6MZGejeStvQ==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "4.22.0",
+                        "@typescript-eslint/types": "4.22.1",
                         "eslint-visitor-keys": "^2.0.0"
                     }
                 }
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz",
-            "integrity": "sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.1.tgz",
+            "integrity": "sha512-svYlHecSMCQGDO2qN1v477ax/IDQwWhc7PRBiwAdAMJE7GXk5stF4Z9R/8wbRkuX/5e9dHqbIWxjeOjckK3wLQ==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/scope-manager": "4.22.0",
-                "@typescript-eslint/types": "4.22.0",
-                "@typescript-eslint/typescript-estree": "4.22.0",
+                "@typescript-eslint/scope-manager": "4.22.1",
+                "@typescript-eslint/types": "4.22.1",
+                "@typescript-eslint/typescript-estree": "4.22.1",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
             },
             "dependencies": {
                 "@typescript-eslint/scope-manager": {
-                    "version": "4.22.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
-                    "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
+                    "version": "4.22.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.1.tgz",
+                    "integrity": "sha512-d5bAiPBiessSmNi8Amq/RuLslvcumxLmyhf1/Xa9IuaoFJ0YtshlJKxhlbY7l2JdEk3wS0EnmnfeJWSvADOe0g==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "4.22.0",
-                        "@typescript-eslint/visitor-keys": "4.22.0"
+                        "@typescript-eslint/types": "4.22.1",
+                        "@typescript-eslint/visitor-keys": "4.22.1"
                     }
                 },
                 "@typescript-eslint/types": {
-                    "version": "4.22.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
-                    "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
+                    "version": "4.22.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.1.tgz",
+                    "integrity": "sha512-2HTkbkdAeI3OOcWbqA8hWf/7z9c6gkmnWNGz0dKSLYLWywUlkOAQ2XcjhlKLj5xBFDf8FgAOF5aQbnLRvgNbCw==",
                     "dev": true
                 },
                 "@typescript-eslint/typescript-estree": {
-                    "version": "4.22.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
-                    "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
+                    "version": "4.22.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.1.tgz",
+                    "integrity": "sha512-p3We0pAPacT+onSGM+sPR+M9CblVqdA9F1JEdIqRVlxK5Qth4ochXQgIyb9daBomyQKAXbygxp1aXQRV0GC79A==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "4.22.0",
-                        "@typescript-eslint/visitor-keys": "4.22.0",
+                        "@typescript-eslint/types": "4.22.1",
+                        "@typescript-eslint/visitor-keys": "4.22.1",
                         "debug": "^4.1.1",
                         "globby": "^11.0.1",
                         "is-glob": "^4.0.1",
@@ -295,53 +295,53 @@
                     }
                 },
                 "@typescript-eslint/visitor-keys": {
-                    "version": "4.22.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
-                    "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
+                    "version": "4.22.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.1.tgz",
+                    "integrity": "sha512-WPkOrIRm+WCLZxXQHCi+WG8T2MMTUFR70rWjdWYddLT7cEfb2P4a3O/J2U1FBVsSFTocXLCoXWY6MZGejeStvQ==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "4.22.0",
+                        "@typescript-eslint/types": "4.22.1",
                         "eslint-visitor-keys": "^2.0.0"
                     }
                 }
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.0.tgz",
-            "integrity": "sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.1.tgz",
+            "integrity": "sha512-l+sUJFInWhuMxA6rtirzjooh8cM/AATAe3amvIkqKFeMzkn85V+eLzb1RyuXkHak4dLfYzOmF6DXPyflJvjQnw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.22.0",
-                "@typescript-eslint/types": "4.22.0",
-                "@typescript-eslint/typescript-estree": "4.22.0",
+                "@typescript-eslint/scope-manager": "4.22.1",
+                "@typescript-eslint/types": "4.22.1",
+                "@typescript-eslint/typescript-estree": "4.22.1",
                 "debug": "^4.1.1"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
-            "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.1.tgz",
+            "integrity": "sha512-d5bAiPBiessSmNi8Amq/RuLslvcumxLmyhf1/Xa9IuaoFJ0YtshlJKxhlbY7l2JdEk3wS0EnmnfeJWSvADOe0g==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.22.0",
-                "@typescript-eslint/visitor-keys": "4.22.0"
+                "@typescript-eslint/types": "4.22.1",
+                "@typescript-eslint/visitor-keys": "4.22.1"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
-            "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.1.tgz",
+            "integrity": "sha512-2HTkbkdAeI3OOcWbqA8hWf/7z9c6gkmnWNGz0dKSLYLWywUlkOAQ2XcjhlKLj5xBFDf8FgAOF5aQbnLRvgNbCw==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
-            "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.1.tgz",
+            "integrity": "sha512-p3We0pAPacT+onSGM+sPR+M9CblVqdA9F1JEdIqRVlxK5Qth4ochXQgIyb9daBomyQKAXbygxp1aXQRV0GC79A==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.22.0",
-                "@typescript-eslint/visitor-keys": "4.22.0",
+                "@typescript-eslint/types": "4.22.1",
+                "@typescript-eslint/visitor-keys": "4.22.1",
                 "debug": "^4.1.1",
                 "globby": "^11.0.1",
                 "is-glob": "^4.0.1",
@@ -350,12 +350,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.22.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
-            "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.1.tgz",
+            "integrity": "sha512-WPkOrIRm+WCLZxXQHCi+WG8T2MMTUFR70rWjdWYddLT7cEfb2P4a3O/J2U1FBVsSFTocXLCoXWY6MZGejeStvQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.22.0",
+                "@typescript-eslint/types": "4.22.1",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -693,12 +693,6 @@
             "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
             "dev": true
         },
-        "big.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-            "dev": true
-        },
         "binary": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
@@ -745,14 +739,14 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
-            "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
+            "version": "4.16.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+            "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001208",
+                "caniuse-lite": "^1.0.30001219",
                 "colorette": "^1.2.2",
-                "electron-to-chromium": "^1.3.712",
+                "electron-to-chromium": "^1.3.723",
                 "escalade": "^3.1.1",
                 "node-releases": "^1.1.71"
             }
@@ -775,16 +769,6 @@
             "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
             "dev": true
         },
-        "call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
-            }
-        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -798,9 +782,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001211",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001211.tgz",
-            "integrity": "sha512-v3GXWKofIkN3PkSidLI5d1oqeKNsam9nQkqieoMhP87nxOY0RPDC8X2+jcv8pjV4dRozPLSoMqNii9sDViOlIg==",
+            "version": "1.0.30001222",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001222.tgz",
+            "integrity": "sha512-rPmwUK0YMjfMlZVmH6nVB5U3YJ5Wnx3vmT5lnRO3nIKO8bJ+TRWMbGuuiSugDJqESy/lz+1hSrlQEagCtoOAWQ==",
             "dev": true
         },
         "chainsaw": {
@@ -1003,21 +987,15 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.717",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
-            "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
+            "version": "1.3.727",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
+            "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
             "dev": true
         },
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
-        },
-        "emojis-list": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
             "dev": true
         },
         "enhanced-resolve": {
@@ -1063,9 +1041,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
-            "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+            "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
@@ -1395,17 +1373,6 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
-        "get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
-            }
-        },
         "get-stream": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
@@ -1496,12 +1463,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
-        },
-        "has-symbols": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
             "dev": true
         },
         "he": {
@@ -1599,15 +1560,6 @@
                 "binary-extensions": "^2.0.0"
             }
         },
-        "is-boolean-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-            "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.0"
-            }
-        },
         "is-core-module": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
@@ -1641,12 +1593,6 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
-        "is-number-object": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-            "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-            "dev": true
-        },
         "is-plain-obj": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -1666,12 +1612,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
             "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-            "dev": true
-        },
-        "is-string": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
             "dev": true
         },
         "isarray": {
@@ -1737,15 +1677,6 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
-        "json5": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5"
-            }
-        },
         "kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -1773,17 +1704,6 @@
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
             "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
             "dev": true
-        },
-        "loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-            "dev": true,
-            "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
-            }
         },
         "locate-path": {
             "version": "6.0.0",
@@ -2183,9 +2103,9 @@
             }
         },
         "postcss": {
-            "version": "8.2.10",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
-            "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
+            "version": "8.2.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.14.tgz",
+            "integrity": "sha512-+jD0ZijcvyCqPQo/m/CW0UcARpdFylq04of+Q7RKX6f/Tu+dvpUI/9Sp81+i6/vJThnOBX09Quw0ZLOVwpzX3w==",
             "requires": {
                 "colorette": "^1.2.2",
                 "nanoid": "^3.1.22",
@@ -2358,9 +2278,9 @@
             "dev": true
         },
         "sass": {
-            "version": "1.32.11",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.11.tgz",
-            "integrity": "sha512-O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==",
+            "version": "1.32.12",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.12.tgz",
+            "integrity": "sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==",
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0"
             }
@@ -2567,26 +2487,24 @@
             }
         },
         "table": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.3.0.tgz",
-            "integrity": "sha512-gM9kB7aNIuSagW89Fh+SdL49uhKnVSORxMcV72u/dfptFdqExInNn5M21wgq/Uf5UdJpsboFhNe/0SoNKjaxzg==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
+            "integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
             "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.flatten": "^4.4.0",
                 "lodash.truncate": "^4.4.2",
                 "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.0"
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0"
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
-                    "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
+                    "version": "8.2.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
+                    "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -2674,14 +2592,13 @@
             "dev": true
         },
         "ts-loader": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.0.0.tgz",
-            "integrity": "sha512-okLMCTkzp1lCldwJ+/+mEY66qilDpwAs5Xs8REG9IwjfbG9fRQmt4a6XCFeFU6XaVI2C0qOEEEu+jIcWAUgc4w==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.1.2.tgz",
+            "integrity": "sha512-ryMgATvLLl+z8zQvdlm6Pep0slmwxFWIEnq/5VdiLVjqQXnFJgO+qNLGIIP+d2N2jsFZ9MibZCVDb2bSp7OmEA==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
                 "enhanced-resolve": "^5.0.0",
-                "loader-utils": "^2.0.0",
                 "micromatch": "^4.0.0",
                 "semver": "^7.3.4"
             }
@@ -2784,9 +2701,9 @@
             }
         },
         "webpack": {
-            "version": "5.34.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.34.0.tgz",
-            "integrity": "sha512-+WiFMgaZqhu7zKN64LQ7z0Ml4WWI+9RwG6zmS0wJDQXiCeg3hpN8fYFNJ+6WlosDT55yVxTfK7XHUAOVR4rLyA==",
+            "version": "5.36.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.36.2.tgz",
+            "integrity": "sha512-XJumVnnGoH2dV+Pk1VwgY4YT6AiMKpVoudUFCNOXMIVrEKPUgEwdIfWPjIuGLESAiS8EdIHX5+TiJz/5JccmRg==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
@@ -2794,7 +2711,7 @@
                 "@webassemblyjs/ast": "1.11.0",
                 "@webassemblyjs/wasm-edit": "1.11.0",
                 "@webassemblyjs/wasm-parser": "1.11.0",
-                "acorn": "^8.0.4",
+                "acorn": "^8.2.1",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
                 "enhanced-resolve": "^5.8.0",
@@ -2815,9 +2732,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "8.1.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
-                    "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
+                    "version": "8.2.4",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
+                    "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
-    "description": "Compile Sass or Scss to CSS at realtime with live browser reload.",
-    "version": "5.0.2",
+    "description": "Compile Sass or Scss to CSS at realtime.",
+    "version": "5.0.3",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -215,7 +215,7 @@
                         "Error",
                         "None"
                     ],
-                    "default": "Warning",
+                    "default": "Information",
                     "description": "Set the level of logging that is recorded and shown to you.\nDefault is `Warning`"
                 },
                 "liveSassCompile.settings.forceBaseDirectory": {
@@ -255,28 +255,28 @@
         "fdir": "^5.0.0",
         "picomatch": "^2.2.3",
         "postcss": "^8.2.10",
-        "sass": "^1.32.11"
+        "sass": "^1.32.12"
     },
     "devDependencies": {
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
-        "@types/node": "^14.14.41",
+        "@types/node": "^15.0.2",
         "@types/picomatch": "^2.2.2",
         "@types/sass": "^1.16.0",
         "@types/vscode": "^1.50.0",
-        "@typescript-eslint/eslint-plugin": "^4.22.0",
-        "@typescript-eslint/parser": "^4.22.0",
-        "eslint": "^7.24.0",
+        "@typescript-eslint/eslint-plugin": "^4.22.1",
+        "@typescript-eslint/parser": "^4.22.1",
+        "eslint": "^7.25.0",
         "mocha": "^8.3.2",
         "terser-webpack-plugin": "^5.1.1",
-        "ts-loader": "^9.0.0",
+        "ts-loader": "^9.1.2",
         "typescript": "^4.2.4",
         "vscode-test": "^1.5.2",
-        "webpack": "^5.34.0",
+        "webpack": "^5.36.2",
         "webpack-cli": "^4.6.0"
     },
     "announcement": {
-        "onVersion": "5.0.2",
-        "message": "SassCompiler v5.0.2: Just some dependancy bumps. Please note: there have been lots of changes in v5! Please see the changelog for all the details, including those about the breaking changes."
+        "onVersion": "5.0.3",
+        "message": "SassCompiler v5.0.2: Changed the default value of a setting and some dependancy bumps. Please note: there have been lots of changes in v5! Please see the changelog for all the details, including those about the breaking changes."
     }
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -26,8 +26,8 @@ export class Helper {
             case "Debug":
                 return OutputLevel.Debug;
 
-            case "Information":
-                return OutputLevel.Information;
+            case "Warning":
+                return OutputLevel.Warning;
 
             case "Error":
                 return OutputLevel.Error;
@@ -35,9 +35,9 @@ export class Helper {
             case "None":
                 return OutputLevel.Critical;
 
-            case "Warning":
+            case "Information":
             default:
-                return OutputLevel.Warning;
+                return OutputLevel.Information;
         }
     }
 }


### PR DESCRIPTION
# 5.0.3 - 2021-05-05

### Changed
- The default for `liveSassCompile.settings.showOutputWindowOn` is now `Information`
  - To prevent future issues like [#70](https://github.com/glenn2223/vscode-live-sass-compiler/issues/70) & [#76](https://github.com/glenn2223/vscode-live-sass-compiler/issues/76). *Where issues are created because, by default, compiling didn't output the same details that the original extension did*
- Updated the documentation to match the above change - and also sorted a couple of typos
- Removed reference to live reload in `package.json`

### Updated
- `postcss` from `8.2.10` to `8.2.14`
  - Fixed ReDoS vulnerabilities in source map parsing
  - Other small changes *(nothing user facing)*
- `sass` from `1.32.11` to `1.32.12`
  - Fix a bug that disallowed more than one module from extending the same selector from a module if that selector itself extended a selector from another upstream module.
- Various dev dependency updates *(nothing user facing)*