### PR TITLE
v5.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Publish - vsce
       if: success() && matrix.os == 'ubuntu-latest' && !github.event.release.prerelease
-      run: vsce publish --yarn
+      run: vsce publish --packagePath live-sass-${{ steps.get-name.outputs.tag }}.vsix
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
         
     - name: Install the package dependencies
       run: npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [5.2.1] - 2022-03-13
+## [5.3.0] - 2022-03-13
 
 ### Fixed
 - Stopped outputting a workspace warning when saving a none SASS file - Closes [#160](https://github.com/glenn2223/vscode-live-sass-compiler/issues/160)
@@ -457,6 +457,7 @@ The new commands are:
 | 0.0.1 | 11.07.17 | Initial Preview Release with following key features. <br> – Live SASS & SCSS Compile. <br> – Customizable file location of exported CSS. <br> – Customizable exported CSS Style (`expanded`, `compact`, `compressed`, `nested`.)<br> – Quick Status bar control.<br> – Live Reload to browser (`Live Server` extension dependency). |
 
 
+[5.3.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.2.0...v5.3.0
 [5.2.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.1.1...v5.2.0
 [5.1.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.0.4...v5.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
   
 ### Other
 - Document changes to reflect the changes made in this release
+- Showed correct message for disabling autoprefix setting (was `null`, supposed to be `false`)
 
 ## [5.2.0] - 2022-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [5.2.1] - 2022-03-10
+## [5.2.1] - 2022-03-11
+
+### Fixed
+- Stopped outputting a workspace warning when saving a none SASS file - Closes [#160](https://github.com/glenn2223/vscode-live-sass-compiler/issues/160)
 
 ### Added
 - Made changes for easier migration from the original extension - Closes [#159](https://github.com/glenn2223/vscode-live-sass-compiler/issues/159)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.2.1] - 2022-03-10
+
+### Added
+- Made changes for easier migration from the original extension - Closes [#159](https://github.com/glenn2223/vscode-live-sass-compiler/issues/159)
+  - Re-added `showOutputWindow` as a deprecated setting. Then when `false` is provided it only outputs at `Warning` and above
+  - Allowed `null` in the `autoprefixer` setting. This works the same as providing `false`
+  
+### Other
+- Document changes to reflect the changes made in this release
+
 ## [5.2.0] - 2022-02-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [5.2.1] - 2022-03-11
+## [5.2.1] - 2022-03-13
 
 ### Fixed
 - Stopped outputting a workspace warning when saving a none SASS file - Closes [#160](https://github.com/glenn2223/vscode-live-sass-compiler/issues/160)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -194,6 +194,8 @@ Autoprefix unsupported CSS properties (e.g. `transform` will also add `-ms-trans
 
     If neither of these are found then Autoprefixer will use `"defaults"`
 
+**Note:** for backwards compatibility with the original extension `null` is permitted. This has the same result as providing `false`
+
 ---
 
 ### liveSassCompile.settings.showOutputWindowOn
@@ -231,6 +233,18 @@ Set the logging level at which errors will be shown in the output window. *There
   - A lot of sub-process by sub-process details of progress
 
 </details>
+
+---
+
+### liveSassCompile.settings.showOutputWindow
+>ℹ This setting is deprecated in favour of `showOutputWindowOn`. However, it will likely never be removed
+
+This setting exists for backwards compatibility with the original extension
+
+When `true` the extension will output all `Information` level messages (from above setting). When `false` it will report all `Warning` level messages (from above setting).
+
+**Type:** `boolean?`
+**Default:** `null`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -261,10 +261,11 @@
                 "liveSassCompile.settings.autoprefix": {
                     "type": [
                         "array",
-                        "boolean"
+                        "boolean",
+                        "null"
                     ],
                     "default": "defaults",
-                    "description": "Automatically add vendor prefixes to unsupported CSS properties (e. g. transform -> -ms-transform). Specify what browsers to target with an array of strings (uses [Browserslist](https://github.com/ai/browserslist)). Pass `null` to turn off.",
+                    "description": "Automatically add vendor prefixes to unsupported CSS properties (e. g. transform -> -ms-transform). Specify what browsers to target with an array of strings (uses [Browserslist](https://github.com/ai/browserslist)). Pass `false` to turn off.",
                     "items": {
                         "type": "string"
                     },
@@ -292,6 +293,15 @@
                     ],
                     "default": "Information",
                     "description": "Set the level of logging that is recorded and shown to you.\nDefault is `Information`"
+                },
+                "liveSassCompile.settings.showOutputWindow": {
+                    "type": [
+                        "bool",
+                        "null"
+                    ],
+                    "deprecationMessage": "Please use showOutputWindowOn instead",
+                    "default": null,
+                    "description": "Backwards compatible setting for those migrating from the original extension"
                 },
                 "liveSassCompile.settings.forceBaseDirectory": {
                     "type": [

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -1324,12 +1324,13 @@ export class AppModel {
 
     private static getWorkspaceFolder(filePath: string) {
         const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(filePath));
+        const filename = filePath.toLowerCase();
 
         if (workspaceFolder) {
             OutputWindow.Show(OutputLevel.Trace, "Found the workspace folder", [
                 `Workspace Name: ${workspaceFolder.name}`,
             ]);
-        } else {
+        } else if (filename.endsWith(".sass") || filename.endsWith(".scss")) {
             OutputWindow.Show(OutputLevel.Warning, "Warning: File is not in a workspace", [
                 `Path: ${filePath}`,
             ]);

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -406,12 +406,13 @@ export class AppModel {
         ]);
 
         const generateMap = Helper.getConfigSettings<boolean>("generateMap", folder),
-            autoprefixerTarget = Helper.getConfigSettings<Array<string> | boolean>(
-                "autoprefix",
-                folder
-            ),
             compileResult = SassHelper.compileOne(sassPath, targetCssUri, mapFileUri, options),
             promises: Promise<IFileResolver>[] = [];
+        
+        let autoprefixerTarget = Helper.getConfigSettings<Array<string> | boolean | null>(
+                "autoprefix",
+                folder
+            );
 
         if (compileResult.errorString !== null) {
             OutputWindow.Show(OutputLevel.Error, "Compilation Error", [compileResult.errorString]);
@@ -433,6 +434,10 @@ export class AppModel {
             StatusBarUi.compilationError(this.isWatching);
 
             return false;
+        }
+
+        if (autoprefixerTarget === null) {
+            autoprefixerTarget = false;
         }
 
         if (autoprefixerTarget != false) {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -39,8 +39,13 @@ export class Helper {
                 return OutputLevel.Critical;
 
             case "Information":
-            default:
-                return OutputLevel.Information;
+            default: {
+                const oldSetting = this.configSettings().get("showOutputWindow") as boolean | null;
+
+                return oldSetting == false
+                    ? OutputLevel.Warning
+                    : OutputLevel.Information;
+            }
         }
     }
 


### PR DESCRIPTION
# 5.3.0 - 2022-03-13

### Fixed
- Stopped outputting a workspace warning when saving a none SASS file - Closes [#160](https://github.com/glenn2223/vscode-live-sass-compiler/issues/160)

### Added
- Made changes for easier migration from the original extension - Closes [#159](https://github.com/glenn2223/vscode-live-sass-compiler/issues/159)
  - Re-added `showOutputWindow` as a deprecated setting. Then when `false` is provided it only outputs at `Warning` and above
  - Allowed `null` in the `autoprefixer` setting. This works the same as providing `false`
  
### Other
- Document changes to reflect the changes made in this release
- Showed correct message for disabling autoprefix setting (was `null`, supposed to be `false`)