### PR TITLE
v5.3.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,15 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        include:
-          - os: macos-latest
-            target: darwin-x64 darwin-arm64
-          - os: ubuntu-latest
-            target: linux-x64 linux-arm64 linux-armhf alpine-x64 alpine-arm64
-          - os: windows-latest
-            target: win32-x64 win32-ia32 win32-arm64
+        os: [ubuntu-latest]
+#        os: [macos-latest, ubuntu-latest, windows-latest]
+#        include:
+#          - os: macos-latest
+#            target: darwin-x64 darwin-arm64
+#          - os: ubuntu-latest
+#            target: linux-x64 linux-arm64 linux-armhf alpine-x64 alpine-arm64
+#          - os: windows-latest
+#            target: win32-x64 win32-ia32 win32-arm64
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -47,11 +48,11 @@ jobs:
 
     - name: Package - vsce (for asset upload)
       if: success()
-      run: vsce package --target ${{ matrix.target }}
+      run: vsce package #--target ${{ matrix.target }}
 
     - name: Publish - vsce
       if: success() && !github.event.release.prerelease
-      run: vsce publish --target ${{ matrix.target }}
+      run: vsce publish #--target ${{ matrix.target }}
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
@@ -68,7 +69,6 @@ jobs:
     - name: Upload asset
       uses: softprops/action-gh-release@v0.1.14
       with:
-        files: |
-          **.vsix
+        files: /*.vsix
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish CI
 
 on:
-# ONLY CARE ABOUT RELEASES - AS TESTS ARE FAILING
-#  pull_request:
-#    branches: [ master ]
   release:
     types:
     - published
@@ -15,9 +12,14 @@ jobs:
   build:
     strategy:
       matrix:
-#       AGAIN ONLY THE RELEASE
-#        os: [macos-latest, ubuntu-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            target: darwin-x64 darwin-arm64
+          - os: ubuntu-latest
+            target: linux-x64 linux-arm64 linux-armhf alpine-x64 alpine-arm64
+          - os: windows-latest
+            target: win32-x64 win32-ia32 win32-arm64
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -40,36 +42,33 @@ jobs:
 #      if: runner.os != 'Linux'
 #      name: Test extension
 
-# Removed && startsWith( github.ref, 'refs/tags/')
-    - id: get-name
-      if: success() && matrix.os == 'ubuntu-latest' 
-      run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
-
     - name: Install vsce
-      run: npm i vsce@2.5.3 -g
+      run: npm i vsce -g
 
-    - name: Package
-      run: vsce package --yarn
+    - name: Package - vsce (for asset upload)
+      if: success()
+      run: vsce package --target ${{ matrix.target }}
 
     - name: Publish - vsce
-      if: success() && matrix.os == 'ubuntu-latest' && !github.event.release.prerelease
-      run: vsce publish --packagePath live-sass-${{ steps.get-name.outputs.tag }}.vsix
+      if: success() && !github.event.release.prerelease
+      run: vsce publish --target ${{ matrix.target }}
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
     - name: Install ovsx
+      if: success() && matrix.os == 'ubuntu-latest' && !github.event.release.prerelease
       run: npm i ovsx -g
       
     - name: Publish - ovsx
-      if: success() && matrix.os == 'ubuntu-latest'
-      run: ovsx publish live-sass-${{ steps.get-name.outputs.tag }}.vsix
+      if: success() && matrix.os == 'ubuntu-latest' && !github.event.release.prerelease
+      run: ovsx publish
       env:
         OVSX_PAT: ${{ secrets.OVSX_PAT }}
         
     - name: Upload asset
-      if: matrix.os == 'ubuntu-latest'
-      uses: softprops/action-gh-release@v0.1.5
+      uses: softprops/action-gh-release@v0.1.14
       with:
-        files: live-sass-${{ steps.get-name.outputs.tag }}.vsix
+        files: |
+          **.vsix
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ Types of changes
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [5.3.1] - 2022-03-31
+
+### Updated
+- `autoprefixer` from `10.4.2` to `10.4.4`
+  - Other changes *(nothing user facing)*
+- `postcss` from `8.4.5` to `8.4.12`
+  - Various changes *(nothing user facing)*
+- `sass` from `1.49.8` to `1.49.10`
+  - Quiet deps mode now silences compiler warnings in mixins and functions that are defined in dependencies even if they're invoked from application stylesheets.
+  - In expanded mode, Sass will now emit colors using `rgb()`, `rbga()`, `hsl()`, and `hsla()` function notation if they were defined using the corresponding notation. As per our browser support policy, this change was only done once 95% of browsers were confirmed to support this output format, and so is not considered a breaking change.  
+    _Note that this output format is intended for human readability and not for interoperability with other tools. As always, Sass targets the CSS specification, and any tool that consumes Sass's output should parse all colors that are supported by the CSS spec._
+  - Fix a bug in which a color written using the four- or eight-digit hex format could be emitted as a hex color rather than a format with higher browser compatibility.
+  - Calculations are no longer simplified within supports declarations
+  - Various changes *(nothing user facing)*
+- Various dev dependency updates *(nothing user facing)*
+
+### Other
+- Tweaked the publish action to allow easier publishing
+
 ## [5.3.0] - 2022-03-13
 
 ### Fixed
@@ -457,6 +476,7 @@ The new commands are:
 | 0.0.1 | 11.07.17 | Initial Preview Release with following key features. <br> – Live SASS & SCSS Compile. <br> – Customizable file location of exported CSS. <br> – Customizable exported CSS Style (`expanded`, `compact`, `compressed`, `nested`.)<br> – Quick Status bar control.<br> – Live Reload to browser (`Live Server` extension dependency). |
 
 
+[5.3.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.3.0...v5.3.1
 [5.3.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.2.0...v5.3.0
 [5.2.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.1.1...v5.2.0
 [5.1.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v5.1.0...v5.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "live-sass",
-    "version": "5.3.0",
+    "version": "5.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -11,34 +11,26 @@
             "dev": true
         },
         "@eslint/eslintrc": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-            "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+            "integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
                 "espree": "^9.3.1",
                 "globals": "^13.9.0",
-                "ignore": "^4.0.6",
+                "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
                 "minimatch": "^3.0.4",
                 "strip-json-comments": "^3.1.1"
-            },
-            "dependencies": {
-                "ignore": {
-                    "version": "4.0.6",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-                    "dev": true
-                }
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
-            "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
@@ -151,20 +143,20 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.64.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.64.0.tgz",
-            "integrity": "sha512-bSlAWz5WtcSL3cO9tAT/KpEH9rv5OBnm93OIIFwdCshaAiqr2bp1AUyEwW9MWeCvZBHEXc3V0fTYVdVyzDNwHA==",
+            "version": "1.65.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+            "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz",
-            "integrity": "sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.17.0.tgz",
+            "integrity": "sha512-qVstvQilEd89HJk3qcbKt/zZrfBZ+9h2ynpAGlWjWiizA7m/MtLT9RoX6gjtpE500vfIg8jogAkDzdCxbsFASQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.12.1",
-                "@typescript-eslint/type-utils": "5.12.1",
-                "@typescript-eslint/utils": "5.12.1",
+                "@typescript-eslint/scope-manager": "5.17.0",
+                "@typescript-eslint/type-utils": "5.17.0",
+                "@typescript-eslint/utils": "5.17.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -174,52 +166,52 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.12.1.tgz",
-            "integrity": "sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.17.0.tgz",
+            "integrity": "sha512-aRzW9Jg5Rlj2t2/crzhA2f23SIYFlF9mchGudyP0uiD6SenIxzKoLjwzHbafgHn39dNV/TV7xwQkLfFTZlJ4ig==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.12.1",
-                "@typescript-eslint/types": "5.12.1",
-                "@typescript-eslint/typescript-estree": "5.12.1",
+                "@typescript-eslint/scope-manager": "5.17.0",
+                "@typescript-eslint/types": "5.17.0",
+                "@typescript-eslint/typescript-estree": "5.17.0",
                 "debug": "^4.3.2"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz",
-            "integrity": "sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.17.0.tgz",
+            "integrity": "sha512-062iCYQF/doQ9T2WWfJohQKKN1zmmXVfAcS3xaiialiw8ZUGy05Em6QVNYJGO34/sU1a7a+90U3dUNfqUDHr3w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.12.1",
-                "@typescript-eslint/visitor-keys": "5.12.1"
+                "@typescript-eslint/types": "5.17.0",
+                "@typescript-eslint/visitor-keys": "5.17.0"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.12.1.tgz",
-            "integrity": "sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.17.0.tgz",
+            "integrity": "sha512-3hU0RynUIlEuqMJA7dragb0/75gZmwNwFf/QJokWzPehTZousP/MNifVSgjxNcDCkM5HI2K22TjQWUmmHUINSg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.12.1",
+                "@typescript-eslint/utils": "5.17.0",
                 "debug": "^4.3.2",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.12.1.tgz",
-            "integrity": "sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.17.0.tgz",
+            "integrity": "sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz",
-            "integrity": "sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz",
+            "integrity": "sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.12.1",
-                "@typescript-eslint/visitor-keys": "5.12.1",
+                "@typescript-eslint/types": "5.17.0",
+                "@typescript-eslint/visitor-keys": "5.17.0",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -228,26 +220,26 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.12.1.tgz",
-            "integrity": "sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.17.0.tgz",
+            "integrity": "sha512-DVvndq1QoxQH+hFv+MUQHrrWZ7gQ5KcJzyjhzcqB1Y2Xes1UQQkTRPUfRpqhS8mhTWsSb2+iyvDW1Lef5DD7vA==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.12.1",
-                "@typescript-eslint/types": "5.12.1",
-                "@typescript-eslint/typescript-estree": "5.12.1",
+                "@typescript-eslint/scope-manager": "5.17.0",
+                "@typescript-eslint/types": "5.17.0",
+                "@typescript-eslint/typescript-estree": "5.17.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz",
-            "integrity": "sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==",
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.17.0.tgz",
+            "integrity": "sha512-6K/zlc4OfCagUu7Am/BD5k8PSWQOgh34Nrv9Rxe2tBzlJ7uOeJ/h7ugCGDCeEZHT6k2CJBhbk9IsbkPI0uvUkA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.12.1",
+                "@typescript-eslint/types": "5.17.0",
                 "eslint-visitor-keys": "^3.0.0"
             }
         },
@@ -524,13 +516,13 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
-            "integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
+            "version": "10.4.4",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
+            "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
             "requires": {
-                "browserslist": "^4.19.1",
-                "caniuse-lite": "^1.0.30001297",
-                "fraction.js": "^4.1.2",
+                "browserslist": "^4.20.2",
+                "caniuse-lite": "^1.0.30001317",
+                "fraction.js": "^4.2.0",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
                 "postcss-value-parser": "^4.2.0"
@@ -594,14 +586,14 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.19.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-            "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+            "version": "4.20.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+            "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
             "requires": {
-                "caniuse-lite": "^1.0.30001286",
-                "electron-to-chromium": "^1.4.17",
+                "caniuse-lite": "^1.0.30001317",
+                "electron-to-chromium": "^1.4.84",
                 "escalade": "^3.1.1",
-                "node-releases": "^2.0.1",
+                "node-releases": "^2.0.2",
                 "picocolors": "^1.0.0"
             }
         },
@@ -636,9 +628,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001300",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-            "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA=="
+            "version": "1.0.30001322",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
+            "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew=="
         },
         "chainsaw": {
             "version": "0.1.0",
@@ -659,36 +651,6 @@
                 "supports-color": "^7.1.0"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
                 "supports-color": {
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -848,9 +810,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.48",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.48.tgz",
-            "integrity": "sha512-RT3SEmpv7XUA+tKXrZGudAWLDpa7f8qmhjcLaM6OD/ERxjQ/zAojT8/Vvo0BSzbArkElFZ1WyZ9FuwAYbkdBNA=="
+            "version": "1.4.101",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.101.tgz",
+            "integrity": "sha512-XJH+XmJjACx1S7ASl/b//KePcda5ocPnFH2jErztXcIS8LpP0SE6rX8ZxiY5/RaDPnaF1rj0fPaHfppzb0e2Aw=="
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -859,9 +821,9 @@
             "dev": true
         },
         "enhanced-resolve": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-            "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+            "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.4",
@@ -892,12 +854,12 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.9.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-            "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
+            "integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.1.0",
+                "@eslint/eslintrc": "^1.2.1",
                 "@humanwhocodes/config-array": "^0.9.2",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
@@ -1175,9 +1137,9 @@
             "dev": true
         },
         "fraction.js": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz",
-            "integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA=="
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+            "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA=="
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -1267,9 +1229,9 @@
             "dev": true
         },
         "globals": {
-            "version": "13.12.1",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-            "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+            "version": "13.13.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+            "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -1607,28 +1569,28 @@
             "dev": true
         },
         "micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
             "dev": true,
             "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
             }
         },
         "mime-db": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.34",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
             "requires": {
-                "mime-db": "1.51.0"
+                "mime-db": "1.52.0"
             }
         },
         "mimic-fn": {
@@ -1647,9 +1609,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "mkdirp": {
@@ -1662,9 +1624,9 @@
             }
         },
         "mocha": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
-            "integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+            "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
             "dev": true,
             "requires": {
                 "@ungap/promise-all-settled": "1.1.2",
@@ -1680,9 +1642,9 @@
                 "he": "1.2.0",
                 "js-yaml": "4.1.0",
                 "log-symbols": "4.1.0",
-                "minimatch": "3.0.4",
+                "minimatch": "4.2.1",
                 "ms": "2.1.3",
-                "nanoid": "3.2.0",
+                "nanoid": "3.3.1",
                 "serialize-javascript": "6.0.0",
                 "strip-json-comments": "3.1.1",
                 "supports-color": "8.1.1",
@@ -1710,6 +1672,15 @@
                         }
                     }
                 },
+                "minimatch": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+                    "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
                 "ms": {
                     "version": "2.1.3",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1725,9 +1696,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -1742,9 +1713,9 @@
             "dev": true
         },
         "node-releases": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-            "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+            "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
         },
         "normalize-path": {
             "version": "3.0.0",
@@ -1919,11 +1890,11 @@
             }
         },
         "postcss": {
-            "version": "8.4.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-            "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
+            "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
             "requires": {
-                "nanoid": "^3.2.0",
+                "nanoid": "^3.3.1",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             }
@@ -2083,9 +2054,9 @@
             "dev": true
         },
         "sass": {
-            "version": "1.49.8",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.8.tgz",
-            "integrity": "sha512-NoGOjvDDOU9og9oAxhRnap71QaTjjlzrvLnKecUJ3GxhaQBrV6e7gPuSPF28u1OcVAArVojPAe4ZhOXwwC4tGw==",
+            "version": "1.49.10",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.10.tgz",
+            "integrity": "sha512-w37zfWJwKu4I78U4z63u1mmgoncq+v3iOB4yzQMPyAPVHHawaQSnu9C9ysGQnZEhW609jkcLioJcMCqm75JMdg==",
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -2308,9 +2279,9 @@
             "dev": true
         },
         "ts-loader": {
-            "version": "9.2.6",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.6.tgz",
-            "integrity": "sha512-QMTC4UFzHmu9wU2VHZEmWWE9cUajjfcdcws+Gh7FhiO+Dy0RnR1bNz0YCHqhI0yRowCE9arVnNxYHqELOy9Hjw==",
+            "version": "9.2.8",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.8.tgz",
+            "integrity": "sha512-gxSak7IHUuRtwKf3FIPSW1VpZcqF9+MBrHOvBp9cjHh+525SjtCIJKVGjRKIAfxBwDGDGCFF00rTfzB1quxdSw==",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
@@ -2350,9 +2321,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-            "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "dev": true
         },
         "unzipper": {
@@ -2417,9 +2388,9 @@
             }
         },
         "webpack": {
-            "version": "5.69.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.69.1.tgz",
-            "integrity": "sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==",
+            "version": "5.70.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
+            "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
@@ -2431,7 +2402,7 @@
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.8.3",
+                "enhanced-resolve": "^5.9.2",
                 "es-module-lexer": "^0.9.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime.",
-    "version": "5.3.0",
+    "version": "5.3.1",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -336,11 +336,11 @@
         "lint": "eslint -c .eslintrc.js --ext .ts ./src/"
     },
     "dependencies": {
-        "autoprefixer": "^10.4.2",
+        "autoprefixer": "^10.4.4",
         "fdir": "^5.2.0",
         "picomatch": "^2.3.1",
-        "postcss": "^8.4.6",
-        "sass": "^1.49.8"
+        "postcss": "^8.4.12",
+        "sass": "^1.49.10"
     },
     "devDependencies": {
         "@types/glob": "^7.2.0",
@@ -348,19 +348,19 @@
         "@types/node": "^15.14.9",
         "@types/picomatch": "^2.3.0",
         "@types/vscode": "^1.52.0",
-        "@typescript-eslint/eslint-plugin": "^5.12.1",
-        "@typescript-eslint/parser": "^5.12.1",
-        "eslint": "^8.9.0",
-        "mocha": "^9.2.1",
+        "@typescript-eslint/eslint-plugin": "^5.17.0",
+        "@typescript-eslint/parser": "^5.17.0",
+        "eslint": "^8.12.0",
+        "mocha": "^9.2.2",
         "terser-webpack-plugin": "^5.3.1",
-        "ts-loader": "^9.2.6",
-        "typescript": "^4.5.5",
+        "ts-loader": "^9.2.8",
+        "typescript": "^4.6.3",
         "vscode-test": "^1.6.1",
-        "webpack": "^5.69.1",
+        "webpack": "^5.70.0",
         "webpack-cli": "^4.9.2"
     },
     "announcement": {
-        "onVersion": "5.3.0",
-        "message": "SassCompiler v5.3.0: Bug fixes and easier migration from original extension"
+        "onVersion": "5.3.1",
+        "message": "SassCompiler v5.3.1: Dependency bumps"
     }
 }


### PR DESCRIPTION
# 5.3.1 - 2022-03-31

### Updated
- `autoprefixer` from `10.4.2` to `10.4.4`
  - Other changes *(nothing user facing)*
- `postcss` from `8.4.5` to `8.4.12`
  - Various changes *(nothing user facing)*
- `sass` from `1.49.8` to `1.49.10`
  - Quiet deps mode now silences compiler warnings in mixins and functions that are defined in dependencies even if they're invoked from application stylesheets.
  - In expanded mode, Sass will now emit colors using `rgb()`, `rbga()`, `hsl()`, and `hsla()` function notation if they were defined using the corresponding notation. As per our browser support policy, this change was only done once 95% of browsers were confirmed to support this output format, and so is not considered a breaking change.  
    _Note that this output format is intended for human readability and not for interoperability with other tools. As always, Sass targets the CSS specification, and any tool that consumes Sass's output should parse all colors that are supported by the CSS spec._
  - Fix a bug in which a color written using the four- or eight-digit hex format could be emitted as a hex color rather than a format with higher browser compatibility.
  - Calculations are no longer simplified within supports declarations
  - Various changes *(nothing user facing)*
- Various dev dependency updates *(nothing user facing)*

### Other
- Tweaked the publish action to allow easier publishing