### PR TITLE
v6.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "live-sass",
-    "version": "6.0.3",
+    "version": "6.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "live-sass",
-            "version": "6.0.3",
+            "version": "6.0.4",
             "license": "MIT",
             "dependencies": {
                 "autoprefixer": "^10.4.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime.",
-    "version": "6.0.3",
+    "version": "6.0.4",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -371,7 +371,7 @@
         "vscode-test": "^1.6.1"
     },
     "announcement": {
-        "onVersion": "6.0.3",
-        "message": "SassCompiler v6.0.3: try out a speedier compiler with the new `useNewCompiler` setting. Bug fixes and dependency bumps"
+        "onVersion": "6.0.4",
+        "message": "SassCompiler v6.0.4: try out a speedier compiler with the new `useNewCompiler` setting. Bug fixes and dependency bumps"
     }
 }


### PR DESCRIPTION
# 6.0.4 - 2023-03-28

<small>[Compare to previous release][comp:6.0.4]</small>

### Fixed

-   `formats[].savePath` no longer throws a warning for the valid path `/` - Closes [#282](https://github.com/glenn2223/vscode-live-sass-compiler/issues/282)

### Updated

-   `sass` to `1.60.0` [Changelog][cl:sa]
-   `autoprefixer` to `10.4.14` [Changelog][cl:ap]
-   Various dev dependency updates _(nothing user facing)_

[comp:6.0.4]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v6.0.3...v6.0.4
[cl:ap]: https://github.com/postcss/autoprefixer/blob/main/CHANGELOG.md
[cl:sa]: https://github.com/sass/dart-sass/blob/main/CHANGELOG.md