### PR TITLE
Fix typo in browserslistrc file name

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -200,7 +200,7 @@ Autoprefix unsupported CSS properties (e.g. `transform` will also add `-ms-trans
 -   When `false` Autoprefixer is disabled
 -   When `true` we will try and search for either:
 
-    -   a `.browserlistsrc` file or,
+    -   a `.browserslistrc` file or,
     -   `"browserslist": [ string[] ]` in your `package.json` file
 
         If neither of these are found then Autoprefixer will use `"defaults"`


### PR DESCRIPTION
The proper name for the browserslist config file is .browserslistrc