### PR TITLE
Update SASS past 1.62 by forcing import of node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "fdir": "^6.0.1",
                 "picomatch": "^2.3.1",
                 "postcss": "^8.4.26",
-                "sass": "^1.62.1"
+                "sass": "^1.64.2"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^25.0.3",
@@ -2675,9 +2675,9 @@
             ]
         },
         "node_modules/sass": {
-            "version": "1.62.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
-            "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
+            "version": "1.64.2",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz",
+            "integrity": "sha512-TnDlfc+CRnUAgLO9D8cQLFu/GIjJIzJCGkE7o4ekIGQOH7T3GetiRR/PsTWJUHhkzcSPrARkPI+gNWn5alCzDg==",
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
         "fdir": "^6.0.1",
         "picomatch": "^2.3.1",
         "postcss": "^8.4.26",
-        "sass": "^1.62.1"
+        "sass": "^1.64.2"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.3",


### PR DESCRIPTION
Updated SASS  
_Due to some VS Code weirdness, SASS adding support for browsers caused upgrading further than 1.62.1 to error. Had to specifically declare the use of the Node version._