### PR TITLE
Allow broader `extensionName` values

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -19,7 +19,9 @@ Here's some of the most important changes:
 -   We now require VS Code version 1.74
 -   We are no longer dependant on `ritwickdey.LiveServer`. You can manually add this package to VS Code, if you need it
 -   Some settings have been changed
-    -   `formats[].format` only accepts `compressed` or `expanded`
+    -   `formats[]`:
+        -   `format` only accepts `compressed` or `expanded`
+        -   `extensionName` allows any string that ends in `.css` - and contains no path separators - meaning that `-min.css` is now valid
     -   `autoprefix`:
         -   The default is `defaults`
         -   `null` is no longer accepted, use `false` instead
@@ -34,7 +36,7 @@ Here's some of the most important changes:
     -   `compileOnWatch`: state if files should be compiled upon watching
     -   `forceBaseDirectory`: state the base directory of all you SASS files. Aids in reducing wasted resources while searching for files
     -   `partialsList`: specify what files are actually partials (or which folders contain them)
-    -   `useNewCompiler`: use the latest version of the JS SASS compiler (which has been built to address some issues and has a modern, idiomatic API)
+    -   `useNewCompiler`: use the latest version of the JS SASS compiler. It's quicker, and addresses some issues; but mainly, IT'S QUICKER!
 
 Here are some things you probably won't care about as much
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,15 +17,15 @@
 
 An array of formats. Allows you save to multiple locations, with a customisable format and extension for each
 
-| Properties                | Type                             | Default    | Notes                                                |
-| ------------------------- | -------------------------------- | ---------- | ---------------------------------------------------- |
-| format                    | `expanded` OR `compressed`       | `expanded` | The output style of the generated file               |
-| extensionName             | `.css` OR `.min.css`             | `.css`     | The extension appended to the outputted file         |
-| savePath                  | `string?`                        | `null`     | See [save path notes]                                |
-| savePathReplacementPairs  | `Record<string, string>?`        | `null`     | See [save path notes]                                |
-| <sup>Ŧ</sup>_linefeed_    | `cr` OR `crlf` OR `lf` OR `lfcr` | `lf`       | The linefeed terminator to use                       |
-| <sup>Ŧ</sup>_indentType_  | `space` OR `tab`                 | `space`    | The indentation to use for the `expanded` format     |
-| <sup>Ŧ</sup>_indentWidth_ | `number`                         | `2`        | The indentation width used for the `expanded` format |
+| Properties                | Type                             | Default    | Notes                                                               |
+| ------------------------- | -------------------------------- | ---------- | ------------------------------------------------------------------- |
+| format                    | `expanded` OR `compressed`       | `expanded` | The output style of the generated file                              |
+| extensionName             | `string`                         | `.css`     | The extension appended to the outputted file (must end with `.css`) |
+| savePath                  | `string?`                        | `null`     | See [save path notes]                                               |
+| savePathReplacementPairs  | `Record<string, string>?`        | `null`     | See [save path notes]                                               |
+| <sup>Ŧ</sup>_linefeed_    | `cr` OR `crlf` OR `lf` OR `lfcr` | `lf`       | The linefeed terminator to use                                      |
+| <sup>Ŧ</sup>_indentType_  | `space` OR `tab`                 | `space`    | The indentation to use for the `expanded` format                    |
+| <sup>Ŧ</sup>_indentWidth_ | `number`                         | `2`        | The indentation width used for the `expanded` format                |
 
 <small><sup>Ŧ</sup> These will be removed in SASS v2.0 and are currently unavailable when `liveSassCompile.settings.useNewCompiler` is `true`</small>
 
@@ -55,7 +55,7 @@ An array of formats. Allows you save to multiple locations, with a customisable 
     // (See issue 26: https://github.com/ritwickdey/vscode-live-sass-compiler/issues/26)
     {
         "format": "compressed",
-        "extensionName": ".min.css",
+        "extensionName": ".m.css",
 
         // ~ -> denotes relative to each sass file
         "savePath": "~/../css/"
@@ -65,8 +65,8 @@ An array of formats. Allows you save to multiple locations, with a customisable 
         "format": "compressed",
         "extensionName": ".min.css",
 
-        // "/Assets/SCSS/main.scss" => "/Assets/Style/main.css"
-        // "/Assets/_SASS/main.sass" => "/Assets/Style/main.css"
+        // "/Assets/SCSS/main.scss" => "/Assets/Style/main.min.css"
+        // "/Assets/_SASS/main.sass" => "/Assets/Style/main.min.css"
         "savePathReplacementPairs": {
             "/SCSS/": "/Style/",
             "/_SASS/": "/Style/"
@@ -74,9 +74,9 @@ An array of formats. Allows you save to multiple locations, with a customisable 
     // Segment replacement can work with relative `savePath`s
     {
         "format": "compressed",
-        "extensionName": ".min.css",
+        "extensionName": "-min.css",
 
-        // "/src/sass/Homepage/AHH/main.scss" => "/dist/css/Homepage/main.css"
+        // "/src/sass/Homepage/AHH/main.scss" => "/dist/css/Homepage/main-min.css"
         "savePath": "~/..",
         "savePathReplacementPairs": {
             "/src/sass": "/dist/css/"

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,15 +17,15 @@
 
 An array of formats. Allows you save to multiple locations, with a customisable format and extension for each
 
-| Properties                | Type                             | Default    | Notes                                                               |
-| ------------------------- | -------------------------------- | ---------- | ------------------------------------------------------------------- |
-| format                    | `expanded` OR `compressed`       | `expanded` | The output style of the generated file                              |
-| extensionName             | `string`                         | `.css`     | The extension appended to the outputted file (must end with `.css`) |
-| savePath                  | `string?`                        | `null`     | See [save path notes]                                               |
-| savePathReplacementPairs  | `Record<string, string>?`        | `null`     | See [save path notes]                                               |
-| <sup>Ŧ</sup>_linefeed_    | `cr` OR `crlf` OR `lf` OR `lfcr` | `lf`       | The linefeed terminator to use                                      |
-| <sup>Ŧ</sup>_indentType_  | `space` OR `tab`                 | `space`    | The indentation to use for the `expanded` format                    |
-| <sup>Ŧ</sup>_indentWidth_ | `number`                         | `2`        | The indentation width used for the `expanded` format                |
+| Properties                | Type                             | Default    | Notes                                                                |
+| ------------------------- | -------------------------------- | ---------- | -------------------------------------------------------------------- |
+| format                    | `expanded` OR `compressed`       | `expanded` | The output style of the generated file                               |
+| extensionName             | `string`                         | `.css`     | The extension suffix added to the output file (must end with `.css`) |
+| savePath                  | `string?`                        | `null`     | See [save path notes]                                                |
+| savePathReplacementPairs  | `Record<string, string>?`        | `null`     | See [save path notes]                                                |
+| <sup>Ŧ</sup>_linefeed_    | `cr` OR `crlf` OR `lf` OR `lfcr` | `lf`       | The linefeed terminator to use                                       |
+| <sup>Ŧ</sup>_indentType_  | `space` OR `tab`                 | `space`    | The indentation to use for the `expanded` format                     |
+| <sup>Ŧ</sup>_indentWidth_ | `number`                         | `2`        | The indentation width used for the `expanded` format                 |
 
 <small><sup>Ŧ</sup> These will be removed in SASS v2.0 and are currently unavailable when `liveSassCompile.settings.useNewCompiler` is `true`</small>
 

--- a/package.json
+++ b/package.json
@@ -134,10 +134,8 @@
                             "extensionName": {
                                 "description": "Extension Name of exported css",
                                 "type": "string",
-                                "enum": [
-                                    ".css",
-                                    ".min.css"
-                                ],
+                                "pattern": "^[^\\/\\\\]*\\.css$",
+                                "patternErrorMessage": "Must end with `.css` and not contain `/` or `\\`",
                                 "default": ".css"
                             },
                             "savePath": {


### PR DESCRIPTION
- You can now use any string value in `extensionName` - providing it ends in `.css` and contains no path separators
- Updated docs to reflect this (plus minor FAQ tweak)