### PR TITLE
Allow `generateMap` at a `formats[]` level

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -26,10 +26,12 @@ Here's some of the most important changes:
         -   When `true` we will find a `.browserslistrc` file or `browserslist` in your `package.json`. No more duplicating settings!
     -   `showOutputWindow` is now `showOutputWindowOn` and uses log values (`Debug`, `Error`, etc.). It's default log level is `Information` - at this level it will output the same information that the original extension does
 -   Some settings are new!
-    -   `formats[].savePathReplacementPairs`: replace segments in the output path
-    -   `formats[].linefeed`: control the line terminator used
-    -   `formats[].indentType`: control whether indents are spaces or tabs
-    -   `formats[].indentWidth`: control the width of the indentation
+    -   `formats[]`:
+        -   `savePathReplacementPairs`: replace segments in the output path
+        -   `generateMap`: generate map files at a format level (overwriting the top-tier setting of the same name)
+        -   `linefeed`: control the line terminator used
+        -   `indentType`: control whether indents are spaces or tabs
+        -   `indentWidth`: control the width of the indentation
     -   `watchOnLaunch`: state whether you want to watch files upon launch
     -   `compileOnWatch`: state if files should be compiled upon watching
     -   `forceBaseDirectory`: state the base directory of all you SASS files. Aids in reducing wasted resources while searching for files

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -23,6 +23,7 @@ An array of formats. Allows you save to multiple locations, with a customisable 
 | extensionName             | `.css` OR `.min.css`             | `.css`     | The extension appended to the outputted file         |
 | savePath                  | `string?`                        | `null`     | See [save path notes]                                |
 | savePathReplacementPairs  | `Record<string, string>?`        | `null`     | See [save path notes]                                |
+| generateMap               | `boolean?`                       | `null`     | Choose to output maps at a format level instead      |
 | <sup>Ŧ</sup>_linefeed_    | `cr` OR `crlf` OR `lf` OR `lfcr` | `lf`       | The linefeed terminator to use                       |
 | <sup>Ŧ</sup>_indentType_  | `space` OR `tab`                 | `space`    | The indentation to use for the `expanded` format     |
 | <sup>Ŧ</sup>_indentWidth_ | `number`                         | `2`        | The indentation width used for the `expanded` format |
@@ -70,7 +71,10 @@ An array of formats. Allows you save to multiple locations, with a customisable 
         "savePathReplacementPairs": {
             "/SCSS/": "/Style/",
             "/_SASS/": "/Style/"
-        }
+        },
+
+        // Don't create a map file for this "production" output
+        "generateMap": false
     // Segment replacement can work with relative `savePath`s
     {
         "format": "compressed",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,14 @@
                                 ],
                                 "default": null
                             },
+                            "generateMap": {
+                                "description": "Generate a map for this particular output. Note: `null` uses the top level setting (of the same name)",
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ],
+                                "default": null
+                            },
                             "linefeed": {
                                 "description": "Choose the linefeed terminator to use in the CSS output",
                                 "type": "string",

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -5,7 +5,8 @@ export interface IFormat {
     format: "compressed" | "expanded";
     extensionName: string;
     savePath?: string;
-    savePathReplacementPairs?: Record<string, unknown>,
+    savePathReplacementPairs?: Record<string, unknown>;
+    generateMap?: boolean;
     linefeed: "cr" | "crlf" | "lf" | "lfcr";
     indentType: "space" | "tab";
     indentWidth: number;
@@ -41,9 +42,7 @@ export class Helper {
             default: {
                 const oldSetting = this.configSettings().get("showOutputWindow") as boolean | null;
 
-                return oldSetting == false
-                    ? OutputLevel.Warning
-                    : OutputLevel.Information;
+                return oldSetting == false ? OutputLevel.Warning : OutputLevel.Information;
             }
         }
     }


### PR DESCRIPTION
You can now decide to output source maps for each format/output. Now you can have source maps for dev outputs and none for production outputs