### PR TITLE
v6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ Types of changes
 
 All notable changes to this project will be documented in this file.
 
+## [6.1.1] - 2023-08-18
+
+<small>[Compare to previous release][comp:6.1.1]</small>
+
+### Changes
+
+-   Updated sass to v1.66.0 to revert breaking change  
+    "_Drop support for the additional CSS calculations defined in CSS Values
+    and Units 4. Custom Sass functions whose names overlapped with these new
+    CSS functions were being parsed as CSS calculations instead, causing an
+    unintentional breaking change outside our normal compatibility policy
+    for CSS compatibility changes_"
+
+### Updated
+
+-   `sass` to `1.66.0` [Changelog][cl:sa]
+-   `fdir` to `6.1.0` [Changelog][cl:fd]
+-   `postcss` to `8.4.28` [Changelog][cl:pc]
+-   `autoprefixer` to `10.4.15` [Changelog][cl:ap]
+-   Various dev dependency updates _(nothing user facing)_
+
 ## [6.1.0] - 2023-08-12
 
 <small>[Compare to previous release][comp:6.1.0]</small>
@@ -732,6 +753,8 @@ All notable changes to this project will be documented in this file.
 | 0.0.2   | 11.07.17   | Small description updated.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | 0.0.1   | 11.07.17   | Initial Preview Release with following key features. <br> – Live SASS & SCSS Compile. <br> – Customizable file location of exported CSS. <br> – Customizable exported CSS Style (`expanded`, `compact`, `compressed`, `nested`.)<br> – Quick Status bar control.<br> – Live Reload to browser (`Live Server` extension dependency).                                                                                                                                                                                                                                                                                                                                                                          |
 
+[6.1.1]: https://github.com/glenn2223/vscode-live-sass-compiler/releases/tag/v6.1.1
+[comp:6.1.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v6.1.0...v6.1.1
 [6.1.0]: https://github.com/glenn2223/vscode-live-sass-compiler/releases/tag/v6.1.0
 [comp:6.1.0]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v6.0.6...v6.1.0
 [6.0.6]: https://github.com/glenn2223/vscode-live-sass-compiler/releases/tag/v6.0.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,35 +1,35 @@
 {
     "name": "live-sass",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "live-sass",
-            "version": "6.1.0",
+            "version": "6.1.1",
             "license": "MIT",
             "dependencies": {
-                "autoprefixer": "^10.4.14",
-                "fdir": "^6.0.2",
+                "autoprefixer": "^10.4.15",
+                "fdir": "^6.1.0",
                 "picomatch": "^2.3.1",
-                "postcss": "^8.4.27",
-                "sass": "^1.65.1"
+                "postcss": "^8.4.28",
+                "sass": "^1.66.0"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^25.0.4",
                 "@rollup/plugin-json": "^6.0.0",
-                "@rollup/plugin-node-resolve": "^15.1.0",
+                "@rollup/plugin-node-resolve": "^15.2.0",
                 "@rollup/plugin-terser": "^0.4.3",
                 "@rollup/plugin-typescript": "^11.1.2",
                 "@types/mocha": "^10.0.1",
                 "@types/node": "^17.0.45",
                 "@types/picomatch": "^2.3.0",
                 "@types/vscode": "1.74",
-                "@typescript-eslint/eslint-plugin": "^6.3.0",
-                "@typescript-eslint/parser": "^6.3.0",
+                "@typescript-eslint/eslint-plugin": "^6.4.0",
+                "@typescript-eslint/parser": "^6.4.0",
                 "eslint": "^8.47.0",
                 "mocha": "^10.2.0",
-                "rollup": "^3.27.2",
+                "rollup": "^3.28.0",
                 "tslib": "^2.6.1",
                 "typescript": "^5.1.6",
                 "vscode-test": "^1.6.1"
@@ -275,9 +275,9 @@
             }
         },
         "node_modules/@rollup/plugin-node-resolve": {
-            "version": "15.1.0",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.1.0.tgz",
-            "integrity": "sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==",
+            "version": "15.2.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.0.tgz",
+            "integrity": "sha512-mKur03xNGT8O9ODO6FtT43ITGqHWZbKPdVJHZb+iV9QYcdlhUUB0wgknvA4KCUmC5oHJF6O2W1EgmyOQyVUI4Q==",
             "dev": true,
             "dependencies": {
                 "@rollup/pluginutils": "^5.0.1",
@@ -348,9 +348,9 @@
             }
         },
         "node_modules/@rollup/pluginutils": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-            "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.3.tgz",
+            "integrity": "sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "^1.0.0",
@@ -427,21 +427,20 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.3.0.tgz",
-            "integrity": "sha512-IZYjYZ0ifGSLZbwMqIip/nOamFiWJ9AH+T/GYNZBWkVcyNQOFGtSMoWV7RvY4poYCMZ/4lHzNl796WOSNxmk8A==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
+            "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.3.0",
-                "@typescript-eslint/type-utils": "6.3.0",
-                "@typescript-eslint/utils": "6.3.0",
-                "@typescript-eslint/visitor-keys": "6.3.0",
+                "@typescript-eslint/scope-manager": "6.4.0",
+                "@typescript-eslint/type-utils": "6.4.0",
+                "@typescript-eslint/utils": "6.4.0",
+                "@typescript-eslint/visitor-keys": "6.4.0",
                 "debug": "^4.3.4",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.2.4",
                 "natural-compare": "^1.4.0",
-                "natural-compare-lite": "^1.4.0",
                 "semver": "^7.5.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -463,15 +462,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.3.0.tgz",
-            "integrity": "sha512-ibP+y2Gr6p0qsUkhs7InMdXrwldjxZw66wpcQq9/PzAroM45wdwyu81T+7RibNCh8oc0AgrsyCwJByncY0Ongg==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+            "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.3.0",
-                "@typescript-eslint/types": "6.3.0",
-                "@typescript-eslint/typescript-estree": "6.3.0",
-                "@typescript-eslint/visitor-keys": "6.3.0",
+                "@typescript-eslint/scope-manager": "6.4.0",
+                "@typescript-eslint/types": "6.4.0",
+                "@typescript-eslint/typescript-estree": "6.4.0",
+                "@typescript-eslint/visitor-keys": "6.4.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -491,13 +490,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.3.0.tgz",
-            "integrity": "sha512-WlNFgBEuGu74ahrXzgefiz/QlVb+qg8KDTpknKwR7hMH+lQygWyx0CQFoUmMn1zDkQjTBBIn75IxtWss77iBIQ==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+            "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.3.0",
-                "@typescript-eslint/visitor-keys": "6.3.0"
+                "@typescript-eslint/types": "6.4.0",
+                "@typescript-eslint/visitor-keys": "6.4.0"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -508,13 +507,13 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.3.0.tgz",
-            "integrity": "sha512-7Oj+1ox1T2Yc8PKpBvOKWhoI/4rWFd1j7FA/rPE0lbBPXTKjdbtC+7Ev0SeBjEKkIhKWVeZSP+mR7y1Db1CdfQ==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
+            "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.3.0",
-                "@typescript-eslint/utils": "6.3.0",
+                "@typescript-eslint/typescript-estree": "6.4.0",
+                "@typescript-eslint/utils": "6.4.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.0.1"
             },
@@ -535,9 +534,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.3.0.tgz",
-            "integrity": "sha512-K6TZOvfVyc7MO9j60MkRNWyFSf86IbOatTKGrpTQnzarDZPYPVy0oe3myTMq7VjhfsUAbNUW8I5s+2lZvtx1gg==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+            "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -548,13 +547,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.3.0.tgz",
-            "integrity": "sha512-Xh4NVDaC4eYKY4O3QGPuQNp5NxBAlEvNQYOqJquR2MePNxO11E5K3t5x4M4Mx53IZvtpW+mBxIT0s274fLUocg==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+            "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.3.0",
-                "@typescript-eslint/visitor-keys": "6.3.0",
+                "@typescript-eslint/types": "6.4.0",
+                "@typescript-eslint/visitor-keys": "6.4.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -575,17 +574,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.3.0.tgz",
-            "integrity": "sha512-hLLg3BZE07XHnpzglNBG8P/IXq/ZVXraEbgY7FM0Cnc1ehM8RMdn9mat3LubJ3KBeYXXPxV1nugWbQPjGeJk6Q==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
+            "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "@types/json-schema": "^7.0.12",
                 "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.3.0",
-                "@typescript-eslint/types": "6.3.0",
-                "@typescript-eslint/typescript-estree": "6.3.0",
+                "@typescript-eslint/scope-manager": "6.4.0",
+                "@typescript-eslint/types": "6.4.0",
+                "@typescript-eslint/typescript-estree": "6.4.0",
                 "semver": "^7.5.4"
             },
             "engines": {
@@ -600,12 +599,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.3.0.tgz",
-            "integrity": "sha512-kEhRRj7HnvaSjux1J9+7dBen15CdWmDnwrpyiHsFX6Qx2iW5LOBUgNefOFeh2PjWPlNwN8TOn6+4eBU3J/gupw==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+            "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "6.3.0",
+                "@typescript-eslint/types": "6.4.0",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -726,9 +725,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.14",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-            "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
+            "version": "10.4.15",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+            "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -737,11 +736,15 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "browserslist": "^4.21.5",
-                "caniuse-lite": "^1.0.30001464",
+                "browserslist": "^4.21.10",
+                "caniuse-lite": "^1.0.30001520",
                 "fraction.js": "^4.2.0",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
@@ -915,9 +918,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001519",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-            "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
+            "version": "1.0.30001521",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
+            "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1152,9 +1155,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.490",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.490.tgz",
-            "integrity": "sha512-6s7NVJz+sATdYnIwhdshx/N/9O6rvMxmhVoDSDFdj6iA45gHR8EQje70+RYsF4GeB+k0IeNSBnP7yG9ZXJFr7A=="
+            "version": "1.4.495",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.495.tgz",
+            "integrity": "sha512-mwknuemBZnoOCths4GtpU/SDuVMp3uQHKa2UNJT9/aVD6WVRjGpXOxRGX7lm6ILIenTdGXPSTCTDaWos5tEU8Q=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -1385,9 +1388,9 @@
             }
         },
         "node_modules/fdir": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.0.2.tgz",
-            "integrity": "sha512-XJVxBciDoEpRipMYyrTCqVQA4jMTfHNiYNy8OvIGTaQzEFPuMJEvmps+Rouo6rsnivkQax9s5m5gy1lHmY2Hmg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.1.0.tgz",
+            "integrity": "sha512-274qhz5PxNnA/fybOu6apTCUnM0GnO3QazB6VH+oag/7DQskdYq8lm07ZSm90kEQuWYH5GvjAxGruuHrEr0bcg==",
             "peerDependencies": {
                 "picomatch": "2.x"
             },
@@ -2205,12 +2208,6 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "node_modules/natural-compare-lite": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-            "dev": true
-        },
         "node_modules/node-releases": {
             "version": "2.0.13",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
@@ -2359,9 +2356,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.27",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-            "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+            "version": "8.4.28",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
+            "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2573,9 +2570,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.27.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.2.tgz",
-            "integrity": "sha512-YGwmHf7h2oUHkVBT248x0yt6vZkYQ3/rvE5iQuVBh3WO8GcJ6BNeOkpoX1yMHIiBm18EMLjBPIoUDkhgnyxGOQ==",
+            "version": "3.28.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
+            "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -2632,9 +2629,9 @@
             ]
         },
         "node_modules/sass": {
-            "version": "1.65.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.65.1.tgz",
-            "integrity": "sha512-9DINwtHmA41SEd36eVPQ9BJKpn7eKDQmUHmpI0y5Zv2Rcorrh0zS+cFrt050hdNbmmCNKTW3hV5mWfuegNRsEA==",
+            "version": "1.66.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.66.0.tgz",
+            "integrity": "sha512-C3U+RgpAAlTXULZkWwzfysgbbBBo8IZudNAOJAVBLslFbIaZv4MBPkTqhuvpK4lqgdoFiWhnOGMoV4L1FyOBag==",
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "live-sass",
     "displayName": "Live Sass Compiler",
     "description": "Compile Sass or Scss to CSS at realtime.",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "publisher": "glenn2223",
     "author": {
         "name": "Glenn Marks",
@@ -353,33 +353,33 @@
         "rollup": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript"
     },
     "dependencies": {
-        "autoprefixer": "^10.4.14",
-        "fdir": "^6.0.2",
+        "autoprefixer": "^10.4.15",
+        "fdir": "^6.1.0",
         "picomatch": "^2.3.1",
-        "postcss": "^8.4.27",
-        "sass": "^1.65.1"
+        "postcss": "^8.4.28",
+        "sass": "^1.66.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.4",
         "@rollup/plugin-json": "^6.0.0",
-        "@rollup/plugin-node-resolve": "^15.1.0",
+        "@rollup/plugin-node-resolve": "^15.2.0",
         "@rollup/plugin-terser": "^0.4.3",
         "@rollup/plugin-typescript": "^11.1.2",
         "@types/mocha": "^10.0.1",
         "@types/node": "^17.0.45",
         "@types/picomatch": "^2.3.0",
         "@types/vscode": "1.74",
-        "@typescript-eslint/eslint-plugin": "^6.3.0",
-        "@typescript-eslint/parser": "^6.3.0",
+        "@typescript-eslint/eslint-plugin": "^6.4.0",
+        "@typescript-eslint/parser": "^6.4.0",
         "eslint": "^8.47.0",
         "mocha": "^10.2.0",
-        "rollup": "^3.27.2",
+        "rollup": "^3.28.0",
         "tslib": "^2.6.1",
         "typescript": "^5.1.6",
         "vscode-test": "^1.6.1"
     },
     "announcement": {
-        "onVersion": "6.1.0",
-        "message": "SassCompiler v6.1.0: generateMap at formats level, extensionName easing and more! Yes, there's a YouTube video too!"
+        "onVersion": "6.1.1",
+        "message": "SassCompiler v6.1.1: rollback of CSS Values and Units 4 support. Yes, there's helpful [YouTube videos](https://www.youtube.com/playlist?list=PLhdDmC4kQ8MqhX3RtLqfIwz8oaLut1m5X) too!"
     }
 }


### PR DESCRIPTION
# 6.1.1 - 2023-08-18

<small>[Compare to previous release][comp:6.1.1]</small>

### Changes

-   Updated sass to v1.66.0 to revert breaking change
    "_Drop support for the additional CSS calculations defined in CSS Values
    and Units 4. Custom Sass functions whose names overlapped with these new
    CSS functions were being parsed as CSS calculations instead, causing an
    unintentional breaking change outside our normal compatibility policy
    for CSS compatibility changes_"

### Updated

-   `sass` to `1.66.0` [Changelog][cl:sa]
-   `fdir` to `6.1.0` [Changelog][cl:fd]
-   `postcss` to `8.4.28` [Changelog][cl:pc]
-   `autoprefixer` to `10.4.15` [Changelog][cl:ap]
-   Various dev dependency updates _(nothing user facing)_

[comp:6.1.1]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v6.1.0...v6.1.1
[cl:ap]: https://github.com/postcss/autoprefixer/blob/main/CHANGELOG.md
[cl:fd]: https://github.com/thecodrr/fdir/releases
[cl:pc]: https://github.com/postcss/postcss/blob/main/CHANGELOG.md
[cl:sa]: https://github.com/sass/dart-sass/blob/main/CHANGELOG.md