### PR TITLE
Make `sourcesContent` in MAP files optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,14 @@ All notable changes to this project will be documented in this file.
     -   `liveSassCompile.settings.formats[].indentWidth`  
         _Note: these 3 would've been dropped for SASS 2.0 anyway_
     -   `liveSassCompile.settings.useNewCompiler`
+-   Those who historically used `useNewCompiler` will find that source contents are no longer included inline by default.  
+    To restore the old behavior, set `generateMapIncludeSources` to `true`.
 -   Requires VS Code v1.95 or later
+
+### Added
+
+-   New `formats[].generateMapIncludeSources` setting allows you to decide on map output on a format basis. By default, they aren't included  
+    The `liveSassCompile.settings.generateMapIncludeSources` is applied if the formats setting is `null` (its default).
 
 ### Changed
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,13 +17,14 @@
 
 An array of formats. Allows you save to multiple locations, with a customisable format and extension for each
 
-| Properties               | Type                       | Default    | Notes                                                                |
-| ------------------------ | -------------------------- | ---------- | -------------------------------------------------------------------- |
-| format                   | `expanded` OR `compressed` | `expanded` | The output style of the generated file                               |
-| extensionName            | `string`                   | `.css`     | The extension suffix added to the output file (must end with `.css`) |
-| savePath                 | `string?`                  | `null`     | See [save path notes]                                                |
-| savePathReplacementPairs | `Record<string, string>?`  | `null`     | See [save path notes]                                                |
-| generateMap              | `boolean?`                 | `null`     | Choose to output maps at a format level instead                      |
+| Properties                | Type                       | Default    | Notes                                                                |
+| ------------------------- | -------------------------- | ---------- | -------------------------------------------------------------------- |
+| format                    | `expanded` OR `compressed` | `expanded` | The output style of the generated file                               |
+| extensionName             | `string`                   | `.css`     | The extension suffix added to the output file (must end with `.css`) |
+| savePath                  | `string?`                  | `null`     | See [save path notes]                                                |
+| savePathReplacementPairs  | `Record<string, string>?`  | `null`     | See [save path notes]                                                |
+| generateMap               | `boolean?`                 | `null`     | Choose to output maps at a format level instead                      |
+| generateMapIncludeSources | `boolean?`                 | `false`    | Include sourcesContent in the generated source map                   |
 
 <details>
 <summary>Examples</summary>
@@ -184,6 +185,18 @@ Create a companion map file for each of the compiled files
 
 **Type:** `boolean`  
 **Default:** `true`
+
+---
+
+## liveSassCompile.settings.generateMapIncludeSources
+
+> ℹ This setting can vary between workspace folders - [read more][multi-rootfaq]
+
+Include sourcesContent in the generated source map for each compiled CSS.  
+**Note:** this can be overwritten in the `formats[].generateMapIncludeSources` setting
+
+**Type:** `boolean`
+**Default:** `false`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -167,6 +167,14 @@
                                     "null"
                                 ],
                                 "default": null
+                            },
+                            "generateMapIncludeSources": {
+                                "description": "Include sourcesContent in the generated source map for this particular output. Note: `null` uses the top level setting (of the same name)",
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ],
+                                "default": null
                             }
                         },
                         "additionalProperties": false,
@@ -225,6 +233,14 @@
                     ],
                     "default": true,
                     "description": "Set to `false` if you don't want a `.map` file for each compiled CSS.\nDefault is `true`",
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.generateMapIncludeSources": {
+                    "type": [
+                        "boolean"
+                    ],
+                    "default": false,
+                    "description": "Include sourcesContent in the generated source map for each compiled CSS.\nDefault is false.",
                     "scope": "resource"
                 },
                 "liveSassCompile.settings.autoprefix": {

--- a/src/Helpers/SassHelper.ts
+++ b/src/Helpers/SassHelper.ts
@@ -45,7 +45,10 @@ export class SassHelper {
      * @param format - The format object containing the desired options.
      * @returns The Sass options object.
      */
-    static toSassOptions(format: IFormat): Options<"async"> {
+    static toSassOptions(
+        format: IFormat,
+        sourceMapIncludeSources: boolean = false
+    ): Options<"async"> {
         return {
             style: format.format,
             importers: [
@@ -59,7 +62,7 @@ export class SassHelper {
             ],
             logger: SassHelper.loggerProperty,
             sourceMap: true,
-            sourceMapIncludeSources: true,
+            sourceMapIncludeSources: sourceMapIncludeSources,
         };
     }
 

--- a/src/Interfaces/IFormat.ts
+++ b/src/Interfaces/IFormat.ts
@@ -1,10 +1,10 @@
-
 export interface IFormat {
     format: "compressed" | "expanded";
     extensionName: string;
     savePath?: string;
     savePathReplacementPairs?: Record<string, unknown>;
     generateMap?: boolean;
+    generateMapIncludeSources?: boolean;
     linefeed: "cr" | "crlf" | "lf" | "lfcr";
     indentType: "space" | "tab";
     indentWidth: number;

--- a/src/appModel.ts
+++ b/src/appModel.ts
@@ -410,7 +410,18 @@ export class AppModel {
             return false;
         }
 
-        const options = SassHelper.toSassOptions(format);
+        // Resolve generateMapIncludeSources: per-format overrides global
+        const generateMapIncludeSources =
+            format.generateMapIncludeSources ??
+            SettingsHelper.getConfigSettings<boolean>(
+                "generateMapIncludeSources",
+                folder
+            );
+
+        const options = SassHelper.toSassOptions(
+            format,
+            generateMapIncludeSources
+        );
 
         const generateMap =
                 format.generateMap ??


### PR DESCRIPTION
-   Those who historically used `useNewCompiler` will find that source contents are no longer included inline by default.
    To restore the old behavior, set `generateMapIncludeSources` to `true`.

### Added

-   New `formats[].generateMapIncludeSources` setting allows you to decide on map output on a format basis. By default, they aren't included
    The `liveSassCompile.settings.generateMapIncludeSources` is applied if the formats setting is `null` (its default).