### PR TITLE
v6.1.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,10 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 16.x
 
@@ -66,10 +66,16 @@ jobs:
               env:
                   OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
-            - name: Upload asset
+            - name: Upload VSIX to release
+              uses: softprops/action-gh-release@v2
+              if: github.ref_type == 'tag'
+              with:
+                  files: |
+                      **/*.vsix
+
+            - name: Upload artifact for temporary reference
+              if: github.ref_type == 'tag'
               uses: actions/upload-artifact@v3.1.2
               with:
                   path: |
                       **/*.vsix
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ Types of changes
 
 All notable changes to this project will be documented in this file.
 
+## [6.1.4] - 2025-07-24
+
+<small>[Compare to previous release][comp:6.1.4]</small>
+
+### Fixed
+
+-   Silence legacy API warnings (N/A to those using the `useNewCompiler` setting). Closes [#405](https://github.com/glenn2223/vscode-live-sass-compiler/issues/405)
+
+### Changes
+
+-   `publish.yml` now uses the latest action releases and also adds the VSIX to releases
+
 ## [6.1.3] - 2025-07-21
 
 <small>[Compare to previous release][comp:6.1.3]</small>
@@ -782,6 +794,8 @@ All notable changes to this project will be documented in this file.
 | 0.0.2   | 11.07.17   | Small description updated.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | 0.0.1   | 11.07.17   | Initial Preview Release with following key features. <br> – Live SASS & SCSS Compile. <br> – Customizable file location of exported CSS. <br> – Customizable exported CSS Style (`expanded`, `compact`, `compressed`, `nested`.)<br> – Quick Status bar control.<br> – Live Reload to browser (`Live Server` extension dependency).                                                                                                                                                                                                                                                                                                                                                                          |
 
+[6.1.4]: https://github.com/glenn2223/vscode-live-sass-compiler/releases/tag/v6.1.4
+[comp:6.1.4]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v6.1.3...v6.1.4
 [6.1.3]: https://github.com/glenn2223/vscode-live-sass-compiler/releases/tag/v6.1.3
 [comp:6.1.3]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v6.1.2...v6.1.3
 [6.1.2]: https://github.com/glenn2223/vscode-live-sass-compiler/releases/tag/v6.1.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "live-sass",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "live-sass",
-      "version": "6.1.3",
+      "version": "6.1.4",
       "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.4.21",

--- a/package.json
+++ b/package.json
@@ -1,385 +1,385 @@
 {
-  "name": "live-sass",
-  "displayName": "Live Sass Compiler",
-  "description": "Compile Sass or Scss to CSS at realtime.",
-  "version": "6.1.3",
-  "publisher": "glenn2223",
-  "author": {
-    "name": "Glenn Marks",
-    "url": "https://github.com/glenn2223/"
-  },
-  "engines": {
-    "vscode": "^1.74.0"
-  },
-  "keywords": [
-    "SASS",
-    "SCSS",
-    "Compiler",
-    "Transpiler",
-    "SASS Compiler"
-  ],
-  "categories": [
-    "Other",
-    "Extension Packs"
-  ],
-  "galleryBanner": {
-    "color": "#41205f",
-    "theme": "dark"
-  },
-  "activationEvents": [
-    "workspaceContains:**/*.s[ac]ss",
-    "onLanguage:scss",
-    "onLanguage:sass"
-  ],
-  "main": "./out/extension",
-  "contributes": {
-    "commands": [
-      {
-        "command": "liveSass.command.watchMySass",
-        "title": "Watch Sass",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.donotWatchMySass",
-        "title": "Stop Watching",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.compileCurrentSass",
-        "title": "Compile Current Sass File",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.oneTimeCompileSass",
-        "title": "Compile Sass - Without Watch Mode",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.openOutputWindow",
-        "title": "Open Live Sass Output Window",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.createIssue",
-        "title": "Report an issue",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.debugInclusion",
-        "title": "Check file will be included",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.debugFileList",
-        "title": "Get all included files",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.showOutputOn.trace",
-        "title": "Show Output On: Trace",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.showOutputOn.debug",
-        "title": "Show Output On: Debug",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.showOutputOn.information",
-        "title": "Show Output On: Information",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.showOutputOn.warning",
-        "title": "Show Output On: Warning",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.showOutputOn.error",
-        "title": "Show Output On: Error",
-        "category": "Live Sass"
-      },
-      {
-        "command": "liveSass.command.showOutputOn.none",
-        "title": "Show Output On: None",
-        "category": "Live Sass"
-      }
+    "name": "live-sass",
+    "displayName": "Live Sass Compiler",
+    "description": "Compile Sass or Scss to CSS at realtime.",
+    "version": "6.1.4",
+    "publisher": "glenn2223",
+    "author": {
+        "name": "Glenn Marks",
+        "url": "https://github.com/glenn2223/"
+    },
+    "engines": {
+        "vscode": "^1.74.0"
+    },
+    "keywords": [
+        "SASS",
+        "SCSS",
+        "Compiler",
+        "Transpiler",
+        "SASS Compiler"
     ],
-    "configuration": {
-      "title": "Live Sass Compiler",
-      "properties": {
-        "liveSassCompile.settings.formats": {
-          "type": "array",
-          "default": [
+    "categories": [
+        "Other",
+        "Extension Packs"
+    ],
+    "galleryBanner": {
+        "color": "#41205f",
+        "theme": "dark"
+    },
+    "activationEvents": [
+        "workspaceContains:**/*.s[ac]ss",
+        "onLanguage:scss",
+        "onLanguage:sass"
+    ],
+    "main": "./out/extension",
+    "contributes": {
+        "commands": [
             {
-              "format": "expanded",
-              "extensionName": ".css",
-              "savePath": null,
-              "savePathReplacementPairs": null
-            }
-          ],
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "properties": {
-              "format": {
-                "description": "Style of exported css",
-                "type": "string",
-                "enum": [
-                  "expanded",
-                  "compressed"
-                ],
-                "default": "expanded"
-              },
-              "extensionName": {
-                "description": "Extension Name of exported css",
-                "type": "string",
-                "pattern": "^[^\\/\\\\]*\\.css$",
-                "patternErrorMessage": "Must end with `.css` and not contain `/` or `\\`",
-                "default": ".css"
-              },
-              "savePath": {
-                "description": "Set the save location of exported CSS.\n Set the relative path from Workspace Root.\n '/' stands for your workspace root. \n Example: /subfolder1/subfolder2. (NOTE: if folder does not exist, folder will be created as well).",
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "pattern": "^(?:\\\\|/|~/|~\\\\)(?:.*[^\\\\/]$|$)",
-                "patternErrorMessage": "Must start with any of:\n`/` or `\\` (for workspace root)\n`~/` or `~\\` for relative to the file being processed. Must not end with a path separator (`/` or `\\`)",
-                "default": null
-              },
-              "savePathReplacementPairs": {
-                "description": "A set of key value pairs. When a key is found in the save path it is replaced with the value. (Note: this step happens after savePath has been applied)",
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "default": null
-              },
-              "generateMap": {
-                "description": "Generate a map for this particular output. Note: `null` uses the top level setting (of the same name)",
-                "type": [
-                  "boolean",
-                  "null"
-                ],
-                "default": null
-              },
-              "linefeed": {
-                "description": "Choose the linefeed terminator to use in the CSS output",
-                "type": "string",
-                "enum": [
-                  "cr",
-                  "crlf",
-                  "lf",
-                  "lfcr"
-                ],
-                "default": "lf",
-                "markdownDeprecationMessage": "**BEWARE**: This setting will be removed in [sass v2.0](https://github.com/sass/dart-sass/issues/1585)",
-                "deprecationMessage": "BEWARE: This setting will be removed in sass v2.0"
-              },
-              "indentType": {
-                "description": "Choose the indent type to use in the CSS ouput (for `expanded` formats only)",
-                "type": "string",
-                "enum": [
-                  "space",
-                  "tab"
-                ],
-                "default": "space",
-                "markdownDeprecationMessage": "**BEWARE**: This setting will be removed in [sass v2.0](https://github.com/sass/dart-sass/issues/1585)",
-                "deprecationMessage": "BEWARE: This setting will be removed in sass v2.0"
-              },
-              "indentWidth": {
-                "description": "Choose the indent width to use in the CSS ouput (for `expanded` formats only)",
-                "type": "number",
-                "default": 2,
-                "minimum": 0,
-                "maximum": 10,
-                "markdownDeprecationMessage": "**BEWARE**: This setting will be removed in [sass v2.0](https://github.com/sass/dart-sass/issues/1585)",
-                "deprecationMessage": "BEWARE: This setting will be removed in sass v2.0"
-              }
+                "command": "liveSass.command.watchMySass",
+                "title": "Watch Sass",
+                "category": "Live Sass"
             },
-            "additionalProperties": false,
-            "required": [
-              "format",
-              "extensionName"
-            ]
-          },
-          "description": "Set your exported CSS Styles, Formats & save location.",
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.excludeList": {
-          "type": "array",
-          "default": [
-            "/**/node_modules/**",
-            "/.vscode/**"
-          ],
-          "description": "All Sass/Scss files inside the folders will be excluded. \n\nExamples: \n'/**/node_modules/**',\n'/.vscode/**', \n'/.history/**' \n\nGlob Patterns are accepted.",
-          "items": {
-            "type": "string",
-            "pattern": "^[\\/].+",
-            "patternErrorMessage": "Must start with a path separator (`/` or `\\`)"
-          },
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.includeItems": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "default": null,
-          "description": "This setting is useful when you only deal with a few sass files. Only these Sass files will be included.\nNOTE: There is no need to include partial sass files.",
-          "items": {
-            "type": "string",
-            "pattern": "^[\\/].+(?<![\\/])[.]s[a|c]ss$",
-            "patternErrorMessage": "Must start with a path separator (`/` or `\\`) and end with a `.sass` or `.scss`"
-          },
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.partialsList": {
-          "type": "array",
-          "default": [
-            "/**/_*.s[ac]ss"
-          ],
-          "description": "Specific glob patterns to identify partial files/folders",
-          "items": {
-            "type": "string",
-            "pattern": "^[\\/].+",
-            "patternErrorMessage": "Must start with a path separator (`/` or `\\`)"
-          },
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.generateMap": {
-          "type": [
-            "boolean"
-          ],
-          "default": true,
-          "description": "Set to `false` if you don't want a `.map` file for each compiled CSS.\nDefault is `true`",
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.useNewCompiler": {
-          "type": [
-            "boolean"
-          ],
-          "default": false,
-          "description": "Set to `true` to use new SASS's new `compile` function. It's more performant!",
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.autoprefix": {
-          "type": [
-            "array",
-            "string",
-            "boolean",
-            "null"
-          ],
-          "default": "defaults",
-          "description": "Automatically add vendor prefixes to unsupported CSS properties (e. g. transform -> -ms-transform). Specify what browsers to target with an array of strings (uses [Browserslist](https://github.com/ai/browserslist)). Pass `false` to turn off.",
-          "items": {
-            "type": "string"
-          },
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.watchOnLaunch": {
-          "type": "boolean",
-          "default": false,
-          "description": "Set this to `true` if you want Live Sass Compiler to automatically start watching your .sass or .scss file when you open an applicable workspace\nDefault is `false`"
-        },
-        "liveSassCompile.settings.compileOnWatch": {
-          "type": "boolean",
-          "default": true,
-          "description": "Set this to `false` if you don't want all Sass files to be compiled when Live Sass Compiler starts watching."
-        },
-        "liveSassCompile.settings.showOutputWindowOn": {
-          "type": "string",
-          "enum": [
-            "Trace",
-            "Debug",
-            "Information",
-            "Warning",
-            "Error",
-            "None"
-          ],
-          "default": "Information",
-          "description": "Set the level of logging that is recorded and shown to you.\nDefault is `Information`"
-        },
-        "liveSassCompile.settings.showOutputWindow": {
-          "type": [
-            "boolean",
-            "null"
-          ],
-          "deprecationMessage": "Please use showOutputWindowOn instead",
-          "default": null,
-          "description": "Backwards compatible setting for those migrating from the original extension"
-        },
-        "liveSassCompile.settings.forceBaseDirectory": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "default": null,
-          "pattern": "^[\\/].+[^\\/]$",
-          "patternErrorMessage": "Must start with a path separator (`/` or `\\`) and must not end with one",
-          "description": "Defines a subdirectory to search from (no directory outside of this will be search)",
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.rootIsWorkspace": {
-          "type": "boolean",
-          "default": false,
-          "description": "A leading slash is relative to the workspace, not the drive (e.g C://)",
-          "scope": "resource"
-        },
-        "liveSassCompile.settings.showAnnouncements": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show the announcement whenever a new version is installed"
+            {
+                "command": "liveSass.command.donotWatchMySass",
+                "title": "Stop Watching",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.compileCurrentSass",
+                "title": "Compile Current Sass File",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.oneTimeCompileSass",
+                "title": "Compile Sass - Without Watch Mode",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.openOutputWindow",
+                "title": "Open Live Sass Output Window",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.createIssue",
+                "title": "Report an issue",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.debugInclusion",
+                "title": "Check file will be included",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.debugFileList",
+                "title": "Get all included files",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.showOutputOn.trace",
+                "title": "Show Output On: Trace",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.showOutputOn.debug",
+                "title": "Show Output On: Debug",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.showOutputOn.information",
+                "title": "Show Output On: Information",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.showOutputOn.warning",
+                "title": "Show Output On: Warning",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.showOutputOn.error",
+                "title": "Show Output On: Error",
+                "category": "Live Sass"
+            },
+            {
+                "command": "liveSass.command.showOutputOn.none",
+                "title": "Show Output On: None",
+                "category": "Live Sass"
+            }
+        ],
+        "configuration": {
+            "title": "Live Sass Compiler",
+            "properties": {
+                "liveSassCompile.settings.formats": {
+                    "type": "array",
+                    "default": [
+                        {
+                            "format": "expanded",
+                            "extensionName": ".css",
+                            "savePath": null,
+                            "savePathReplacementPairs": null
+                        }
+                    ],
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "format": {
+                                "description": "Style of exported css",
+                                "type": "string",
+                                "enum": [
+                                    "expanded",
+                                    "compressed"
+                                ],
+                                "default": "expanded"
+                            },
+                            "extensionName": {
+                                "description": "Extension Name of exported css",
+                                "type": "string",
+                                "pattern": "^[^\\/\\\\]*\\.css$",
+                                "patternErrorMessage": "Must end with `.css` and not contain `/` or `\\`",
+                                "default": ".css"
+                            },
+                            "savePath": {
+                                "description": "Set the save location of exported CSS.\n Set the relative path from Workspace Root.\n '/' stands for your workspace root. \n Example: /subfolder1/subfolder2. (NOTE: if folder does not exist, folder will be created as well).",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "pattern": "^(?:\\\\|/|~/|~\\\\)(?:.*[^\\\\/]$|$)",
+                                "patternErrorMessage": "Must start with any of:\n`/` or `\\` (for workspace root)\n`~/` or `~\\` for relative to the file being processed. Must not end with a path separator (`/` or `\\`)",
+                                "default": null
+                            },
+                            "savePathReplacementPairs": {
+                                "description": "A set of key value pairs. When a key is found in the save path it is replaced with the value. (Note: this step happens after savePath has been applied)",
+                                "type": [
+                                    "object",
+                                    "null"
+                                ],
+                                "default": null
+                            },
+                            "generateMap": {
+                                "description": "Generate a map for this particular output. Note: `null` uses the top level setting (of the same name)",
+                                "type": [
+                                    "boolean",
+                                    "null"
+                                ],
+                                "default": null
+                            },
+                            "linefeed": {
+                                "description": "Choose the linefeed terminator to use in the CSS output",
+                                "type": "string",
+                                "enum": [
+                                    "cr",
+                                    "crlf",
+                                    "lf",
+                                    "lfcr"
+                                ],
+                                "default": "lf",
+                                "markdownDeprecationMessage": "**BEWARE**: This setting will be removed in [sass v2.0](https://github.com/sass/dart-sass/issues/1585)",
+                                "deprecationMessage": "BEWARE: This setting will be removed in sass v2.0"
+                            },
+                            "indentType": {
+                                "description": "Choose the indent type to use in the CSS ouput (for `expanded` formats only)",
+                                "type": "string",
+                                "enum": [
+                                    "space",
+                                    "tab"
+                                ],
+                                "default": "space",
+                                "markdownDeprecationMessage": "**BEWARE**: This setting will be removed in [sass v2.0](https://github.com/sass/dart-sass/issues/1585)",
+                                "deprecationMessage": "BEWARE: This setting will be removed in sass v2.0"
+                            },
+                            "indentWidth": {
+                                "description": "Choose the indent width to use in the CSS ouput (for `expanded` formats only)",
+                                "type": "number",
+                                "default": 2,
+                                "minimum": 0,
+                                "maximum": 10,
+                                "markdownDeprecationMessage": "**BEWARE**: This setting will be removed in [sass v2.0](https://github.com/sass/dart-sass/issues/1585)",
+                                "deprecationMessage": "BEWARE: This setting will be removed in sass v2.0"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "format",
+                            "extensionName"
+                        ]
+                    },
+                    "description": "Set your exported CSS Styles, Formats & save location.",
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.excludeList": {
+                    "type": "array",
+                    "default": [
+                        "/**/node_modules/**",
+                        "/.vscode/**"
+                    ],
+                    "description": "All Sass/Scss files inside the folders will be excluded. \n\nExamples: \n'/**/node_modules/**',\n'/.vscode/**', \n'/.history/**' \n\nGlob Patterns are accepted.",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[\\/].+",
+                        "patternErrorMessage": "Must start with a path separator (`/` or `\\`)"
+                    },
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.includeItems": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "default": null,
+                    "description": "This setting is useful when you only deal with a few sass files. Only these Sass files will be included.\nNOTE: There is no need to include partial sass files.",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[\\/].+(?<![\\/])[.]s[a|c]ss$",
+                        "patternErrorMessage": "Must start with a path separator (`/` or `\\`) and end with a `.sass` or `.scss`"
+                    },
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.partialsList": {
+                    "type": "array",
+                    "default": [
+                        "/**/_*.s[ac]ss"
+                    ],
+                    "description": "Specific glob patterns to identify partial files/folders",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[\\/].+",
+                        "patternErrorMessage": "Must start with a path separator (`/` or `\\`)"
+                    },
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.generateMap": {
+                    "type": [
+                        "boolean"
+                    ],
+                    "default": true,
+                    "description": "Set to `false` if you don't want a `.map` file for each compiled CSS.\nDefault is `true`",
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.useNewCompiler": {
+                    "type": [
+                        "boolean"
+                    ],
+                    "default": false,
+                    "description": "Set to `true` to use new SASS's new `compile` function. It's more performant!",
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.autoprefix": {
+                    "type": [
+                        "array",
+                        "string",
+                        "boolean",
+                        "null"
+                    ],
+                    "default": "defaults",
+                    "description": "Automatically add vendor prefixes to unsupported CSS properties (e. g. transform -> -ms-transform). Specify what browsers to target with an array of strings (uses [Browserslist](https://github.com/ai/browserslist)). Pass `false` to turn off.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.watchOnLaunch": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set this to `true` if you want Live Sass Compiler to automatically start watching your .sass or .scss file when you open an applicable workspace\nDefault is `false`"
+                },
+                "liveSassCompile.settings.compileOnWatch": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set this to `false` if you don't want all Sass files to be compiled when Live Sass Compiler starts watching."
+                },
+                "liveSassCompile.settings.showOutputWindowOn": {
+                    "type": "string",
+                    "enum": [
+                        "Trace",
+                        "Debug",
+                        "Information",
+                        "Warning",
+                        "Error",
+                        "None"
+                    ],
+                    "default": "Information",
+                    "description": "Set the level of logging that is recorded and shown to you.\nDefault is `Information`"
+                },
+                "liveSassCompile.settings.showOutputWindow": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "deprecationMessage": "Please use showOutputWindowOn instead",
+                    "default": null,
+                    "description": "Backwards compatible setting for those migrating from the original extension"
+                },
+                "liveSassCompile.settings.forceBaseDirectory": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null,
+                    "pattern": "^[\\/].+[^\\/]$",
+                    "patternErrorMessage": "Must start with a path separator (`/` or `\\`) and must not end with one",
+                    "description": "Defines a subdirectory to search from (no directory outside of this will be search)",
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.rootIsWorkspace": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "A leading slash is relative to the workspace, not the drive (e.g C://)",
+                    "scope": "resource"
+                },
+                "liveSassCompile.settings.showAnnouncements": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show the announcement whenever a new version is installed"
+                }
+            }
         }
-      }
+    },
+    "license": "MIT",
+    "icon": "images/icon2.png",
+    "bugs": {
+        "url": "https://github.com/glenn2223/vscode-live-sass-compiler/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/glenn2223/vscode-live-sass-compiler.git"
+    },
+    "homepage": "https://glenn2223.github.io/vscode-live-sass-compiler/",
+    "scripts": {
+        "vscode:prepublish": "npm run rollup",
+        "pretest": "npm run rollup && tsc -p ./src/test/",
+        "test": "node ./out/test/runTest.js",
+        "lint": "eslint -c .eslintrc.js --ext .ts ./src/",
+        "rollup": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript"
+    },
+    "dependencies": {
+        "autoprefixer": "^10.4.21",
+        "fdir": "^6.4.6",
+        "picomatch": "^3.0.1",
+        "postcss": "^8.5.6",
+        "sass": "^1.89.2"
+    },
+    "devDependencies": {
+        "@rollup/plugin-commonjs": "^25.0.8",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^15.3.1",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^11.1.6",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^17.0.45",
+        "@types/picomatch": "^2.3.4",
+        "@types/vscode": "1.74",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "eslint": "^8.57.1",
+        "mocha": "^10.8.2",
+        "rollup": "^3.29.5",
+        "tslib": "^2.8.1",
+        "typescript": "^5.8.3",
+        "vscode-test": "^1.6.1"
+    },
+    "announcement": {
+        "onVersion": "6.1.3",
+        "message": "SassCompiler v6.1.3: Much needed dependency bumps. Yes, there's helpful [YouTube videos](https://www.youtube.com/playlist?list=PLhdDmC4kQ8MqhX3RtLqfIwz8oaLut1m5X) too!"
     }
-  },
-  "license": "MIT",
-  "icon": "images/icon2.png",
-  "bugs": {
-    "url": "https://github.com/glenn2223/vscode-live-sass-compiler/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/glenn2223/vscode-live-sass-compiler.git"
-  },
-  "homepage": "https://glenn2223.github.io/vscode-live-sass-compiler/",
-  "scripts": {
-    "vscode:prepublish": "npm run rollup",
-    "pretest": "npm run rollup && tsc -p ./src/test/",
-    "test": "node ./out/test/runTest.js",
-    "lint": "eslint -c .eslintrc.js --ext .ts ./src/",
-    "rollup": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript"
-  },
-  "dependencies": {
-    "autoprefixer": "^10.4.21",
-    "fdir": "^6.4.6",
-    "picomatch": "^3.0.1",
-    "postcss": "^8.5.6",
-    "sass": "^1.89.2"
-  },
-  "devDependencies": {
-    "@rollup/plugin-commonjs": "^25.0.8",
-    "@rollup/plugin-json": "^6.1.0",
-    "@rollup/plugin-node-resolve": "^15.3.1",
-    "@rollup/plugin-terser": "^0.4.4",
-    "@rollup/plugin-typescript": "^11.1.6",
-    "@types/mocha": "^10.0.10",
-    "@types/node": "^17.0.45",
-    "@types/picomatch": "^2.3.4",
-    "@types/vscode": "1.74",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
-    "eslint": "^8.57.1",
-    "mocha": "^10.8.2",
-    "rollup": "^3.29.5",
-    "tslib": "^2.8.1",
-    "typescript": "^5.8.3",
-    "vscode-test": "^1.6.1"
-  },
-  "announcement": {
-    "onVersion": "6.1.3",
-    "message": "SassCompiler v6.1.3: Much needed dependency bumps. Yes, there's helpful [YouTube videos](https://www.youtube.com/playlist?list=PLhdDmC4kQ8MqhX3RtLqfIwz8oaLut1m5X) too!"
-  }
 }


### PR DESCRIPTION
# 6.1.4 - 2025-07-24

<small>[Compare to previous release][comp:6.1.4]</small>

### Fixed

-   Silence legacy API warnings (N/A to those using the `useNewCompiler` setting). Closes [#405](https://github.com/glenn2223/vscode-live-sass-compiler/issues/405)

### Changes

-   `publish.yml` now uses the latest action releases and also adds the VSIX to releases

[comp:6.1.4]: https://github.com/glenn2223/vscode-live-sass-compiler/compare/v6.1.3...v6.1.4